### PR TITLE
Update to latest Cranelift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ name = "wasm2obj"
 path = "src/wasm2obj.rs"
 
 [dependencies]
-cranelift-codegen = "0.20.0"
-cranelift-native = "0.20.0"
+cranelift-codegen = "0.22.0"
+cranelift-native = "0.22.0"
 wasmtime-environ = { path = "lib/environ" }
 wasmtime-execute = { path = "lib/execute" }
 wasmtime-obj = { path = "lib/obj" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ name = "wasm2obj"
 path = "src/wasm2obj.rs"
 
 [dependencies]
-cranelift-codegen = "0.22.0"
-cranelift-native = "0.22.0"
+cranelift-codegen = "0.24.0"
+cranelift-native = "0.24.0"
+cranelift-entity = "0.24.0"
+cranelift-wasm = "0.24.0"
 wasmtime-environ = { path = "lib/environ" }
 wasmtime-execute = { path = "lib/execute" }
 wasmtime-obj = { path = "lib/obj" }
@@ -27,7 +29,7 @@ docopt = "1.0.1"
 serde = "1.0.75"
 serde_derive = "1.0.75"
 tempdir = "*"
-faerie = "0.5.0"
-target-lexicon = { version = "0.0.3", default-features = false }
+faerie = "0.6.0"
+target-lexicon = { version = "0.2.0", default-features = false }
 
 [workspace]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,9 @@ cargo-fuzz = true
 [dependencies]
 wasmtime-environ = { path = "../lib/environ" }
 wasmtime-execute = { path = "../lib/execute" }
-cranelift-codegen = "0.20.0"
-cranelift-wasm = "0.20.1"
-cranelift-native = "0.20.0"
+cranelift-codegen = "0.22.0"
+cranelift-wasm = "0.22.0"
+cranelift-native = "0.22.0"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 wasmparser = { version = "0.17.2", default-features = false }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,9 @@ cargo-fuzz = true
 [dependencies]
 wasmtime-environ = { path = "../lib/environ" }
 wasmtime-execute = { path = "../lib/execute" }
-cranelift-codegen = "0.22.0"
-cranelift-wasm = "0.22.0"
-cranelift-native = "0.22.0"
+cranelift-codegen = "0.24.0"
+cranelift-wasm = "0.24.0"
+cranelift-native = "0.24.0"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 wasmparser = { version = "0.17.2", default-features = false }
 

--- a/lib/environ/Cargo.toml
+++ b/lib/environ/Cargo.toml
@@ -10,10 +10,11 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 
 [dependencies]
-cranelift-codegen = "0.20.0"
-cranelift-entity = "0.20.1"
-cranelift-wasm = "0.20.1"
+cranelift-codegen = "0.22.0"
+cranelift-entity = "0.22.0"
+cranelift-wasm = "0.22.0"
 target-lexicon = "0.0.3"
+memoffset = "0.2.1"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/lib/environ/Cargo.toml
+++ b/lib/environ/Cargo.toml
@@ -10,10 +10,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 
 [dependencies]
-cranelift-codegen = "0.22.0"
-cranelift-entity = "0.22.0"
-cranelift-wasm = "0.22.0"
-target-lexicon = "0.0.3"
+cranelift-codegen = "0.24.0"
+cranelift-entity = "0.24.0"
+cranelift-wasm = "0.24.0"
 memoffset = "0.2.1"
 
 [badges]

--- a/lib/environ/src/lib.rs
+++ b/lib/environ/src/lib.rs
@@ -35,7 +35,6 @@
 extern crate cranelift_codegen;
 extern crate cranelift_entity;
 extern crate cranelift_wasm;
-extern crate target_lexicon;
 #[macro_use]
 extern crate memoffset;
 

--- a/lib/environ/src/lib.rs
+++ b/lib/environ/src/lib.rs
@@ -36,10 +36,13 @@ extern crate cranelift_codegen;
 extern crate cranelift_entity;
 extern crate cranelift_wasm;
 extern crate target_lexicon;
+#[macro_use]
+extern crate memoffset;
 
 mod compilation;
 mod environ;
 mod module;
+mod vmcontext;
 
 pub use compilation::{compile_module, Compilation, Relocation, RelocationTarget, Relocations};
 pub use environ::{ModuleEnvironment, ModuleTranslation};

--- a/lib/environ/src/module.rs
+++ b/lib/environ/src/module.rs
@@ -39,7 +39,7 @@ pub enum Export {
 #[derive(Debug)]
 pub struct Module {
     /// Unprocessed signatures exactly as provided by `declare_signature()`.
-    pub signatures: Vec<ir::Signature>,
+    pub signatures: PrimaryMap<SignatureIndex, ir::Signature>,
 
     /// Names of imported functions.
     pub imported_funcs: Vec<(String, String)>,
@@ -48,13 +48,13 @@ pub struct Module {
     pub functions: PrimaryMap<FuncIndex, SignatureIndex>,
 
     /// WebAssembly tables.
-    pub tables: Vec<Table>,
+    pub tables: PrimaryMap<TableIndex, Table>,
 
     /// WebAssembly linear memories.
-    pub memories: Vec<Memory>,
+    pub memories: PrimaryMap<MemoryIndex, Memory>,
 
     /// WebAssembly global variables.
-    pub globals: Vec<Global>,
+    pub globals: PrimaryMap<GlobalIndex, Global>,
 
     /// Exported entities.
     pub exports: HashMap<String, Export>,
@@ -70,12 +70,12 @@ impl Module {
     /// Allocates the module data structures.
     pub fn new() -> Self {
         Self {
-            signatures: Vec::new(),
+            signatures: PrimaryMap::new(),
             imported_funcs: Vec::new(),
             functions: PrimaryMap::new(),
-            tables: Vec::new(),
-            memories: Vec::new(),
-            globals: Vec::new(),
+            tables: PrimaryMap::new(),
+            memories: PrimaryMap::new(),
+            globals: PrimaryMap::new(),
             exports: HashMap::new(),
             start_func: None,
             table_elements: Vec::new(),

--- a/lib/environ/src/vmcontext.rs
+++ b/lib/environ/src/vmcontext.rs
@@ -1,0 +1,33 @@
+/// The main fields a JIT needs to access to utilize a WebAssembly linear,
+/// memory, namely the start address and the size in bytes.
+#[repr(C, packed)]
+pub struct VMMemory {
+    pub base: *mut u8,
+    pub current_length: usize,
+}
+
+/// The main fields a JIT needs to access to utilize a WebAssembly table,
+/// namely the start address and the number of elements.
+#[repr(C, packed)]
+pub struct VMTable {
+    pub base: *mut u8,
+    pub current_num_elements: usize,
+}
+
+/// The VM "context", which is pointed to by the `vmctx` arg in Cranelift.
+/// This has pointers to the globals, memories, tables, and other runtime
+/// state associated with the current instance.
+#[repr(C, packed)]
+pub struct VMContext {
+    /// A pointer to an array of globals.
+    pub globals: *mut u8,
+    /// A pointer to an array of `VMMemory` instances, indexed by
+    /// WebAssembly memory index.
+    pub memories: *mut VMMemory,
+    /// A pointer to an array of `VMTable` instances, indexed by
+    /// WebAssembly table index.
+    pub tables: *mut VMTable,
+    /// A pointer to extra runtime state that isn't directly accessed
+    /// from JIT code.
+    pub instance: *mut u8,
+}

--- a/lib/execute/Cargo.toml
+++ b/lib/execute/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/CraneStation/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
-cranelift-codegen = "0.20.0"
-cranelift-entity = "0.20.1"
-cranelift-wasm = "0.20.1"
+cranelift-codegen = "0.22.0"
+cranelift-entity = "0.22.0"
+cranelift-wasm = "0.22.0"
 region = "0.3.0"
 wasmtime-environ = { path = "../environ" }
-memmap = "0.6.2"
+memmap = "0.7.0"

--- a/lib/execute/Cargo.toml
+++ b/lib/execute/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/CraneStation/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
-cranelift-codegen = "0.22.0"
-cranelift-entity = "0.22.0"
-cranelift-wasm = "0.22.0"
-region = "0.3.0"
+cranelift-codegen = "0.24.0"
+cranelift-entity = "0.24.0"
+cranelift-wasm = "0.24.0"
+region = "1.0.0"
 wasmtime-environ = { path = "../environ" }
 memmap = "0.7.0"

--- a/lib/execute/src/execute.rs
+++ b/lib/execute/src/execute.rs
@@ -84,6 +84,7 @@ fn relocate<F>(
 
 extern "C" fn grow_memory(size: u32, memory_index: u32, vmctx: *mut *mut u8) -> u32 {
     unsafe {
+        // FIXME: update the VMMemory's size
         let instance = (*vmctx.offset(4)) as *mut Instance;
         (*instance)
             .memory_mut(memory_index as MemoryIndex)
@@ -94,6 +95,7 @@ extern "C" fn grow_memory(size: u32, memory_index: u32, vmctx: *mut *mut u8) -> 
 
 extern "C" fn current_memory(memory_index: u32, vmctx: *mut *mut u8) -> u32 {
     unsafe {
+        // FIXME: read the VMMemory's size instead
         let instance = (*vmctx.offset(4)) as *mut Instance;
         (*instance)
             .memory_mut(memory_index as MemoryIndex)
@@ -115,9 +117,12 @@ fn make_vmctx(instance: &mut Instance, mem_base_addrs: &mut [*mut u8]) -> Vec<*m
         .map(|table| (table.as_mut_ptr() as *mut u8, table.len()))
         .unwrap_or((ptr::null_mut(), 0));
 
+    // FIXME: Actually use environ's VMContext struct
     let mut vmctx = Vec::new();
     vmctx.push(instance.globals.as_mut_ptr());
+    // FIXME: These need to be VMMemory now
     vmctx.push(mem_base_addrs.as_mut_ptr() as *mut u8);
+    // FIXME: These need to be VMTable now
     vmctx.push(default_table_ptr);
     vmctx.push(default_table_len as *mut u8);
     vmctx.push(instance as *mut Instance as *mut u8);
@@ -134,7 +139,7 @@ pub fn execute(
     let start_index = module
         .start_func
         .ok_or_else(|| String::from("No start function defined, aborting execution"))?;
-    // TODO: Put all the function bodies into a page-aligned memory region, and
+    // FIXME: Put all the function bodies into a page-aligned memory region, and
     // then make them ReadExecute rather than ReadWriteExecute.
     for code_buf in compilation.functions.values() {
         match unsafe {

--- a/lib/obj/Cargo.toml
+++ b/lib/obj/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["wasm"]
 license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
-cranelift-codegen = "0.20.0"
-cranelift-entity = "0.20.1"
+cranelift-codegen = "0.22.0"
+cranelift-entity = "0.22.0"
 wasmtime-environ = { path = "../environ" }
 faerie = "0.5.0"

--- a/lib/obj/Cargo.toml
+++ b/lib/obj/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["wasm"]
 license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
-cranelift-codegen = "0.22.0"
-cranelift-entity = "0.22.0"
+cranelift-codegen = "0.24.0"
+cranelift-entity = "0.24.0"
 wasmtime-environ = { path = "../environ" }
-faerie = "0.5.0"
+faerie = "0.6.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,9 @@
 )]
 
 extern crate cranelift_codegen;
+extern crate cranelift_entity;
 extern crate cranelift_native;
+extern crate cranelift_wasm;
 extern crate docopt;
 extern crate wasmtime_environ;
 extern crate wasmtime_execute;
@@ -45,6 +47,8 @@ extern crate tempdir;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
+use cranelift_entity::EntityRef;
+use cranelift_wasm::MemoryIndex;
 use docopt::Docopt;
 use std::error::Error;
 use std::fs::File;
@@ -95,9 +99,10 @@ fn main() {
                 .version(Some(String::from("0.0.0")))
                 .deserialize()
         }).unwrap_or_else(|e| e.exit());
-    let (mut flag_builder, isa_builder) = cranelift_native::builders().unwrap_or_else(|_| {
+    let isa_builder = cranelift_native::builder().unwrap_or_else(|_| {
         panic!("host machine is not a supported target");
     });
+    let mut flag_builder = settings::builder();
 
     // Enable verifier passes in debug mode.
     if cfg!(debug_assertions) {
@@ -183,7 +188,7 @@ fn handle_module(args: &Args, path: PathBuf, isa: &TargetIsa) -> Result<(), Stri
                         break;
                     }
                     let memory = instance.inspect_memory(
-                        str::parse(split[0]).unwrap(),
+                        MemoryIndex::new(str::parse(split[0]).unwrap()),
                         str::parse(split[1]).unwrap(),
                         str::parse(split[2]).unwrap(),
                     );


### PR DESCRIPTION
This updates wasmtime to Cranelift 0.24.0, which includes a bunch of API migrations.

Because it was inconvenient to do this separately, this PR also introduces a new instance data structure, declared here: lib/environ/src/vmcontext.rs. The high-level summary is, instead of an array of *mut u8, we now have a repr(C, packed) struct, and we use the `memoffset` crate to compute offsets, which is a lot cleaner than just having magic offsets in various places.

There are a lot of FIXMEs in here, but I think this is enough to get the tree up to date with Cranelift API changes, and also point the way forward for future changes.