### PR TITLE
Check for `cargo fmt` rather than checking for `rustfmt` directly.

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -22,13 +22,13 @@ function banner {
 
 # Run rustfmt if we have it.
 banner "Rust formatting"
-if type rustfmt > /dev/null; then
+if cargo +stable fmt -- --version > /dev/null ; then
     if ! "$topdir/format-all.sh" --check ; then
         echo "Formatting diffs detected! Run \"cargo fmt --all\" to correct."
         exit 1
     fi
 else
-    echo "rustfmt not available; formatting not checked!"
+    echo "cargo-fmt not available; formatting not checked!"
     echo
     echo "If you are using rustup, rustfmt can be installed via"
     echo "\"rustup component add --toolchain=stable rustfmt-preview\", or see"


### PR DESCRIPTION
The format-all.sh script uses `cargo fmt` rather than `rustfmt` directly, so check for `cargo fmt`.

Fixes #24.