### PR TITLE
Switch to passing the vmctx hidden argument at the beginning.

### DIFF
--- a/lib/environ/src/module_environ.rs
+++ b/lib/environ/src/module_environ.rs
@@ -251,8 +251,11 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
 
 /// Add environment-specific function parameters.
 pub fn translate_signature(mut sig: ir::Signature, pointer_type: ir::Type) -> ir::Signature {
-    sig.params
-        .push(AbiParam::special(pointer_type, ArgumentPurpose::VMContext));
+    // Prepend the vmctx argument.
+    sig.params.insert(
+        0,
+        AbiParam::special(pointer_type, ArgumentPurpose::VMContext),
+    );
     sig
 }
 

--- a/lib/runtime/src/instance.rs
+++ b/lib/runtime/src/instance.rs
@@ -387,7 +387,7 @@ impl InstanceContents {
         };
 
         // Make the call.
-        unsafe { wasmtime_call(callee_address, callee_vmctx) }
+        unsafe { wasmtime_call(callee_vmctx, callee_address) }
             .map_err(InstantiationError::StartTrap)
     }
 

--- a/lib/runtime/src/libcalls.rs
+++ b/lib/runtime/src/libcalls.rs
@@ -90,9 +90,9 @@ pub extern "C" fn wasmtime_f64_nearest(x: f64) -> f64 {
 /// Implementation of memory.grow for locally-defined 32-bit memories.
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_memory32_grow(
+    vmctx: *mut VMContext,
     delta: u32,
     memory_index: u32,
-    vmctx: *mut VMContext,
 ) -> u32 {
     let instance_contents = (&mut *vmctx).instance_contents();
     let memory_index = DefinedMemoryIndex::from_u32(memory_index);
@@ -105,9 +105,9 @@ pub unsafe extern "C" fn wasmtime_memory32_grow(
 /// Implementation of memory.grow for imported 32-bit memories.
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_imported_memory32_grow(
+    vmctx: *mut VMContext,
     delta: u32,
     memory_index: u32,
-    vmctx: *mut VMContext,
 ) -> u32 {
     let instance_contents = (&mut *vmctx).instance_contents();
     let memory_index = MemoryIndex::from_u32(memory_index);
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn wasmtime_imported_memory32_grow(
 
 /// Implementation of memory.size for locally-defined 32-bit memories.
 #[no_mangle]
-pub unsafe extern "C" fn wasmtime_memory32_size(memory_index: u32, vmctx: *mut VMContext) -> u32 {
+pub unsafe extern "C" fn wasmtime_memory32_size(vmctx: *mut VMContext, memory_index: u32) -> u32 {
     let instance_contents = (&mut *vmctx).instance_contents();
     let memory_index = DefinedMemoryIndex::from_u32(memory_index);
 
@@ -129,8 +129,8 @@ pub unsafe extern "C" fn wasmtime_memory32_size(memory_index: u32, vmctx: *mut V
 /// Implementation of memory.size for imported 32-bit memories.
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_imported_memory32_size(
-    memory_index: u32,
     vmctx: *mut VMContext,
+    memory_index: u32,
 ) -> u32 {
     let instance_contents = (&mut *vmctx).instance_contents();
     let memory_index = MemoryIndex::from_u32(memory_index);

--- a/lib/runtime/src/traphandlers.rs
+++ b/lib/runtime/src/traphandlers.rs
@@ -91,9 +91,9 @@ fn push_jmp_buf(buf: jmp_buf) {
 /// return values will be written.
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_call_trampoline(
+    vmctx: *mut VMContext,
     callee: *const VMFunctionBody,
     values_vec: *mut u8,
-    vmctx: *mut VMContext,
 ) -> Result<(), String> {
     // Reset JMP_BUFS if the stack is unwound through this point.
     let _guard = ScopeGuard::new();
@@ -106,8 +106,8 @@ pub unsafe extern "C" fn wasmtime_call_trampoline(
     push_jmp_buf(buf);
 
     // Call the function!
-    let func: fn(*mut u8, *mut VMContext) = mem::transmute(callee);
-    func(values_vec, vmctx);
+    let func: fn(*mut VMContext, *mut u8) = mem::transmute(callee);
+    func(vmctx, values_vec);
 
     Ok(())
 }
@@ -116,8 +116,8 @@ pub unsafe extern "C" fn wasmtime_call_trampoline(
 /// return values.
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_call(
-    callee: *const VMFunctionBody,
     vmctx: *mut VMContext,
+    callee: *const VMFunctionBody,
 ) -> Result<(), String> {
     // Reset JMP_BUFS if the stack is unwound through this point.
     let _guard = ScopeGuard::new();


### PR DESCRIPTION
This switches to passing the vmctx hidden argument at the beginning of
the argument list, rather than the end.
