### PR TITLE
Instance API cleanup

### DIFF
--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -26,7 +26,7 @@ fuzz_target!(|data: &[u8]| {
     let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let mut compiler = Compiler::new(isa);
     let mut resolver = NullResolver {};
-    let mut global_exports = Rc::new(RefCell::new(HashMap::new()));
+    let global_exports = Rc::new(RefCell::new(HashMap::new()));
     let _compiled = match CompiledModule::new(&mut compiler, data, &mut resolver, global_exports) {
         Ok(x) => x,
         Err(_) => return,

--- a/lib/jit/src/action.rs
+++ b/lib/jit/src/action.rs
@@ -254,7 +254,11 @@ pub fn inspect_memory<'instance>(
 /// Read a global in this `Instance` identified by an export name.
 pub fn get(instance: &Instance, global_name: &str) -> Result<RuntimeValue, ActionError> {
     let (definition, global) = match unsafe { instance.lookup_immutable(global_name) } {
-        Some(Export::Global { definition, global }) => (definition, global),
+        Some(Export::Global {
+            definition,
+            vmctx: _,
+            global,
+        }) => (definition, global),
         Some(_) => {
             return Err(ActionError::Kind(format!(
                 "exported item \"{}\" is not a global variable",

--- a/lib/jit/src/action.rs
+++ b/lib/jit/src/action.rs
@@ -7,7 +7,7 @@ use core::{fmt, mem, ptr, slice};
 use cranelift_codegen::ir;
 use std::string::String;
 use std::vec::Vec;
-use wasmtime_runtime::{wasmtime_call_trampoline, Export, Instance};
+use wasmtime_runtime::{wasmtime_call_trampoline, Export, InstanceHandle};
 
 /// A runtime value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -125,10 +125,10 @@ pub enum ActionError {
     Type(String),
 }
 
-/// Invoke a function in an `Instance` identified by an export name.
+/// Invoke a function through an `InstanceHandle` identified by an export name.
 pub fn invoke(
     compiler: &mut Compiler,
-    instance: &mut Instance,
+    instance: &mut InstanceHandle,
     function_name: &str,
     args: &[RuntimeValue],
 ) -> Result<ActionOutcome, ActionError> {
@@ -220,7 +220,7 @@ pub fn invoke(
 
 /// Returns a slice of the contents of allocated linear memory.
 pub fn inspect_memory<'instance>(
-    instance: &'instance Instance,
+    instance: &'instance InstanceHandle,
     memory_name: &str,
     start: usize,
     len: usize,
@@ -251,8 +251,8 @@ pub fn inspect_memory<'instance>(
     })
 }
 
-/// Read a global in this `Instance` identified by an export name.
-pub fn get(instance: &Instance, global_name: &str) -> Result<RuntimeValue, ActionError> {
+/// Read a global in the given instance identified by an export name.
+pub fn get(instance: &InstanceHandle, global_name: &str) -> Result<RuntimeValue, ActionError> {
     let (definition, global) = match unsafe { instance.lookup_immutable(global_name) } {
         Some(Export::Global {
             definition,

--- a/lib/jit/src/instantiate.rs
+++ b/lib/jit/src/instantiate.rs
@@ -160,7 +160,7 @@ impl CompiledModule {
         }
     }
 
-    /// Crate an `InstanceContents` from this `CompiledModule`.
+    /// Crate an `Instance` from this `CompiledModule`.
     ///
     /// Note that if only one instance of this module is needed, it may be more
     /// efficient to call the top-level `instantiate`, since that avoids copying

--- a/lib/jit/src/lib.rs
+++ b/lib/jit/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::compiler::Compiler;
 pub use crate::context::{Context, ContextError, UnknownInstance};
 pub use crate::instantiate::{instantiate, CompiledModule, SetupError};
 pub use crate::link::link_module;
-pub use crate::namespace::{InstanceIndex, Namespace};
+pub use crate::namespace::Namespace;
 pub use crate::resolver::{NullResolver, Resolver};
 pub use crate::target_tunables::target_tunables;
 

--- a/lib/jit/src/lib.rs
+++ b/lib/jit/src/lib.rs
@@ -37,8 +37,6 @@ use hashbrown::{hash_map, HashMap};
 use std::collections::{hash_map, HashMap};
 
 #[macro_use]
-extern crate cranelift_entity;
-#[macro_use]
 extern crate failure_derive;
 
 mod action;
@@ -60,9 +58,9 @@ pub use crate::namespace::Namespace;
 pub use crate::resolver::{NullResolver, Resolver};
 pub use crate::target_tunables::target_tunables;
 
-// Re-export `Instance` so that users won't need to separately depend on
+// Re-export `InstanceHandle` so that users won't need to separately depend on
 // wasmtime-runtime in common cases.
-pub use wasmtime_runtime::{Instance, InstantiationError};
+pub use wasmtime_runtime::{InstanceHandle, InstantiationError};
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/jit/src/link.rs
+++ b/lib/jit/src/link.rs
@@ -12,7 +12,7 @@ use wasmtime_environ::{
 };
 use wasmtime_runtime::libcalls;
 use wasmtime_runtime::{
-    Export, Imports, Instance, LinkError, VMFunctionBody, VMFunctionImport, VMGlobalImport,
+    Export, Imports, InstanceHandle, LinkError, VMFunctionBody, VMFunctionImport, VMGlobalImport,
     VMMemoryImport, VMTableImport,
 };
 
@@ -44,7 +44,7 @@ pub fn link_module(
                             signature, import_signature)
                         ));
                     }
-                    dependencies.insert(Instance::from_vmctx(vmctx));
+                    dependencies.insert(InstanceHandle::from_vmctx(vmctx));
                     function_imports.push(VMFunctionImport {
                         body: address,
                         vmctx,
@@ -82,7 +82,7 @@ pub fn link_module(
                             module_name, field,
                         )));
                     }
-                    dependencies.insert(Instance::from_vmctx(vmctx));
+                    dependencies.insert(InstanceHandle::from_vmctx(vmctx));
                     table_imports.push(VMTableImport {
                         from: definition,
                         vmctx,
@@ -136,7 +136,7 @@ pub fn link_module(
                     }
                     assert!(memory.offset_guard_size >= import_memory.offset_guard_size);
 
-                    dependencies.insert(Instance::from_vmctx(vmctx));
+                    dependencies.insert(InstanceHandle::from_vmctx(vmctx));
                     memory_imports.push(VMMemoryImport {
                         from: definition,
                         vmctx,
@@ -180,7 +180,7 @@ pub fn link_module(
                             module_name, field
                         )));
                     }
-                    dependencies.insert(Instance::from_vmctx(vmctx));
+                    dependencies.insert(InstanceHandle::from_vmctx(vmctx));
                     global_imports.push(VMGlobalImport { from: definition });
                 }
             },

--- a/lib/jit/src/namespace.rs
+++ b/lib/jit/src/namespace.rs
@@ -5,7 +5,7 @@
 use super::HashMap;
 use crate::resolver::Resolver;
 use std::string::String;
-use wasmtime_runtime::{Export, Instance};
+use wasmtime_runtime::{Export, InstanceHandle};
 
 /// A namespace containing instances keyed by name.
 ///
@@ -13,7 +13,7 @@ use wasmtime_runtime::{Export, Instance};
 /// imports using defined exports.
 pub struct Namespace {
     /// Mapping from identifiers to indices in `self.instances`.
-    names: HashMap<String, Instance>,
+    names: HashMap<String, InstanceHandle>,
 }
 
 impl Namespace {
@@ -24,14 +24,14 @@ impl Namespace {
         }
     }
 
-    /// Install a new `Instance` in this `Namespace`, optionally with the
-    /// given name, and return its index.
-    pub fn name_instance(&mut self, name: String, instance: Instance) {
+    /// Install a new `InstanceHandle` in this `Namespace`, optionally with the
+    /// given name.
+    pub fn name_instance(&mut self, name: String, instance: InstanceHandle) {
         self.names.insert(name, instance);
     }
 
-    /// Get the instance index registered with the given `instance_name`.
-    pub fn get_instance(&mut self, name: &str) -> Option<&mut Instance> {
+    /// Get the instance registered with the given `instance_name`.
+    pub fn get_instance(&mut self, name: &str) -> Option<&mut InstanceHandle> {
         self.names.get_mut(name)
     }
 }

--- a/lib/jit/src/namespace.rs
+++ b/lib/jit/src/namespace.rs
@@ -3,18 +3,9 @@
 //! and resolve imports to exports among them.
 
 use super::HashMap;
-use crate::action::{get, inspect_memory, invoke};
-use crate::action::{ActionError, ActionOutcome, RuntimeValue};
-use crate::compiler::Compiler;
 use crate::resolver::Resolver;
-use cranelift_entity::PrimaryMap;
 use std::string::String;
 use wasmtime_runtime::{Export, Instance};
-
-/// An opaque reference to an `Instance` within a `Namespace`.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct InstanceIndex(u32);
-entity_impl!(InstanceIndex, "instance");
 
 /// A namespace containing instances keyed by name.
 ///
@@ -22,10 +13,7 @@ entity_impl!(InstanceIndex, "instance");
 /// imports using defined exports.
 pub struct Namespace {
     /// Mapping from identifiers to indices in `self.instances`.
-    names: HashMap<String, InstanceIndex>,
-
-    /// The instances, available by index.
-    instances: PrimaryMap<InstanceIndex, Instance>,
+    names: HashMap<String, Instance>,
 }
 
 impl Namespace {
@@ -33,62 +21,25 @@ impl Namespace {
     pub fn new() -> Self {
         Self {
             names: HashMap::new(),
-            instances: PrimaryMap::new(),
         }
     }
 
     /// Install a new `Instance` in this `Namespace`, optionally with the
     /// given name, and return its index.
-    pub fn instance(&mut self, instance_name: Option<String>, instance: Instance) -> InstanceIndex {
-        let index = self.instances.push(instance);
-        if let Some(instance_name) = instance_name {
-            self.names.insert(instance_name, index);
-        }
-        index
+    pub fn name_instance(&mut self, name: String, instance: Instance) {
+        self.names.insert(name, instance);
     }
 
     /// Get the instance index registered with the given `instance_name`.
-    pub fn get_instance_index(&mut self, instance_name: &str) -> Option<InstanceIndex> {
-        self.names.get_mut(instance_name).cloned()
-    }
-
-    /// Register an additional name for an existing registered instance.
-    pub fn alias_for_indexed(&mut self, existing_index: InstanceIndex, new_name: String) {
-        self.names.insert(new_name, existing_index);
-    }
-
-    /// Invoke an exported function from an instance.
-    pub fn invoke(
-        &mut self,
-        compiler: &mut Compiler,
-        index: InstanceIndex,
-        field_name: &str,
-        args: &[RuntimeValue],
-    ) -> Result<ActionOutcome, ActionError> {
-        invoke(compiler, &mut self.instances[index], field_name, args)
-    }
-
-    /// Get a slice of memory from an instance.
-    pub fn inspect_memory(
-        &self,
-        index: InstanceIndex,
-        field_name: &str,
-        start: usize,
-        len: usize,
-    ) -> Result<&[u8], ActionError> {
-        inspect_memory(&self.instances[index], field_name, start, len)
-    }
-
-    /// Get the value of an exported global from an instance.
-    pub fn get(&self, index: InstanceIndex, field_name: &str) -> Result<RuntimeValue, ActionError> {
-        get(&self.instances[index], field_name)
+    pub fn get_instance(&mut self, name: &str) -> Option<&mut Instance> {
+        self.names.get_mut(name)
     }
 }
 
 impl Resolver for Namespace {
-    fn resolve(&mut self, instance: &str, field: &str) -> Option<Export> {
-        if let Some(index) = self.names.get(instance) {
-            self.instances[*index].lookup(field)
+    fn resolve(&mut self, name: &str, field: &str) -> Option<Export> {
+        if let Some(instance) = self.names.get_mut(name) {
+            instance.lookup(field)
         } else {
             None
         }

--- a/lib/runtime/src/export.rs
+++ b/lib/runtime/src/export.rs
@@ -14,7 +14,7 @@ pub enum Export {
         address: *const VMFunctionBody,
         /// The function signature declaration, used for compatibilty checking.
         signature: ir::Signature,
-        /// Pointer to the containing VMContext.
+        /// Pointer to the containing `VMContext`.
         vmctx: *mut VMContext,
     },
 
@@ -22,7 +22,7 @@ pub enum Export {
     Table {
         /// The address of the table descriptor.
         definition: *mut VMTableDefinition,
-        /// Pointer to the containing VMContext.
+        /// Pointer to the containing `VMContext`.
         vmctx: *mut VMContext,
         /// The table declaration, used for compatibilty checking.
         table: TablePlan,
@@ -32,7 +32,7 @@ pub enum Export {
     Memory {
         /// The address of the memory descriptor.
         definition: *mut VMMemoryDefinition,
-        /// Pointer to the containing VMContext.
+        /// Pointer to the containing `VMContext`.
         vmctx: *mut VMContext,
         /// The memory declaration, used for compatibilty checking.
         memory: MemoryPlan,
@@ -42,7 +42,7 @@ pub enum Export {
     Global {
         /// The address of the global storage.
         definition: *mut VMGlobalDefinition,
-        /// Pointer to the containing VMContext.
+        /// Pointer to the containing `VMContext`.
         vmctx: *mut VMContext,
         /// The global declaration, used for compatibilty checking.
         global: Global,

--- a/lib/runtime/src/export.rs
+++ b/lib/runtime/src/export.rs
@@ -42,6 +42,8 @@ pub enum Export {
     Global {
         /// The address of the global storage.
         definition: *mut VMGlobalDefinition,
+        /// Pointer to the containing VMContext.
+        vmctx: *mut VMContext,
         /// The global declaration, used for compatibilty checking.
         global: Global,
     },
@@ -88,7 +90,15 @@ impl Export {
     }
 
     /// Construct a global export value.
-    pub fn global(definition: *mut VMGlobalDefinition, global: Global) -> Self {
-        Export::Global { definition, global }
+    pub fn global(
+        definition: *mut VMGlobalDefinition,
+        vmctx: *mut VMContext,
+        global: Global,
+    ) -> Self {
+        Export::Global {
+            definition,
+            vmctx,
+            global,
+        }
     }
 }

--- a/lib/runtime/src/export.rs
+++ b/lib/runtime/src/export.rs
@@ -12,10 +12,10 @@ pub enum Export {
     Function {
         /// The address of the native-code function.
         address: *const VMFunctionBody,
-        /// The function signature declaration, used for compatibilty checking.
-        signature: ir::Signature,
         /// Pointer to the containing `VMContext`.
         vmctx: *mut VMContext,
+        /// The function signature declaration, used for compatibilty checking.
+        signature: ir::Signature,
     },
 
     /// A table export value.
@@ -53,13 +53,13 @@ impl Export {
     /// Construct a function export value.
     pub fn function(
         address: *const VMFunctionBody,
-        signature: ir::Signature,
         vmctx: *mut VMContext,
+        signature: ir::Signature,
     ) -> Self {
         Export::Function {
             address,
-            signature,
             vmctx,
+            signature,
         }
     }
 

--- a/lib/runtime/src/imports.rs
+++ b/lib/runtime/src/imports.rs
@@ -1,4 +1,4 @@
-use crate::instance::Instance;
+use crate::instance::InstanceHandle;
 use crate::vmcontext::{VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport};
 use cranelift_entity::{BoxedSlice, PrimaryMap};
 use cranelift_wasm::{FuncIndex, GlobalIndex, MemoryIndex, TableIndex};
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 #[derive(Clone)]
 pub struct Imports {
     /// The set of instances that the imports depend on.
-    pub dependencies: HashSet<Instance>,
+    pub dependencies: HashSet<InstanceHandle>,
 
     /// Resolved addresses for imported functions.
     pub functions: BoxedSlice<FuncIndex, VMFunctionImport>,
@@ -26,7 +26,7 @@ pub struct Imports {
 impl Imports {
     /// Construct a new `Imports` instance.
     pub fn new(
-        dependencies: HashSet<Instance>,
+        dependencies: HashSet<InstanceHandle>,
         function_imports: PrimaryMap<FuncIndex, VMFunctionImport>,
         table_imports: PrimaryMap<TableIndex, VMTableImport>,
         memory_imports: PrimaryMap<MemoryIndex, VMMemoryImport>,

--- a/lib/runtime/src/imports.rs
+++ b/lib/runtime/src/imports.rs
@@ -1,10 +1,15 @@
+use crate::instance::Instance;
 use crate::vmcontext::{VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport};
 use cranelift_entity::{BoxedSlice, PrimaryMap};
 use cranelift_wasm::{FuncIndex, GlobalIndex, MemoryIndex, TableIndex};
+use std::collections::HashSet;
 
 /// Resolved import pointers.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Imports {
+    /// The set of instances that the imports depend on.
+    pub dependencies: HashSet<Instance>,
+
     /// Resolved addresses for imported functions.
     pub functions: BoxedSlice<FuncIndex, VMFunctionImport>,
 
@@ -21,12 +26,14 @@ pub struct Imports {
 impl Imports {
     /// Construct a new `Imports` instance.
     pub fn new(
+        dependencies: HashSet<Instance>,
         function_imports: PrimaryMap<FuncIndex, VMFunctionImport>,
         table_imports: PrimaryMap<TableIndex, VMTableImport>,
         memory_imports: PrimaryMap<MemoryIndex, VMMemoryImport>,
         global_imports: PrimaryMap<GlobalIndex, VMGlobalImport>,
     ) -> Self {
         Self {
+            dependencies,
             functions: function_imports.into_boxed_slice(),
             tables: table_imports.into_boxed_slice(),
             memories: memory_imports.into_boxed_slice(),
@@ -37,6 +44,7 @@ impl Imports {
     /// Construct a new `Imports` instance with no imports.
     pub fn none() -> Self {
         Self {
+            dependencies: HashSet::new(),
             functions: PrimaryMap::new().into_boxed_slice(),
             tables: PrimaryMap::new().into_boxed_slice(),
             memories: PrimaryMap::new().into_boxed_slice(),

--- a/lib/runtime/src/instance.rs
+++ b/lib/runtime/src/instance.rs
@@ -843,7 +843,7 @@ impl InstanceHandle {
 impl Clone for InstanceHandle {
     fn clone(&self) -> Self {
         unsafe { &mut *(self.instance as *mut Instance) }.refcount += 1;
-        InstanceHandle {
+        Self {
             instance: self.instance,
         }
     }

--- a/lib/runtime/src/instance.rs
+++ b/lib/runtime/src/instance.rs
@@ -755,7 +755,7 @@ impl InstanceHandle {
         // invoked automatically at instantiation time.
         instance.invoke_start_function()?;
 
-        Ok(Self { instance: instance })
+        Ok(Self { instance })
     }
 
     /// Create a new `InstanceHandle` pointing at the instance

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -46,7 +46,7 @@ pub mod libcalls;
 
 pub use crate::export::Export;
 pub use crate::imports::Imports;
-pub use crate::instance::{Instance, InstantiationError, LinkError};
+pub use crate::instance::{Instance, InstanceContents, InstantiationError, LinkError};
 pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
 pub use crate::signalhandlers::{wasmtime_init_eager, wasmtime_init_finish};

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -46,7 +46,7 @@ pub mod libcalls;
 
 pub use crate::export::Export;
 pub use crate::imports::Imports;
-pub use crate::instance::{Instance, InstanceContents, InstantiationError, LinkError};
+pub use crate::instance::{InstanceHandle, InstantiationError, LinkError};
 pub use crate::mmap::Mmap;
 pub use crate::sig_registry::SignatureRegistry;
 pub use crate::signalhandlers::{wasmtime_init_eager, wasmtime_init_finish};

--- a/lib/runtime/src/libcalls.rs
+++ b/lib/runtime/src/libcalls.rs
@@ -94,10 +94,10 @@ pub unsafe extern "C" fn wasmtime_memory32_grow(
     delta: u32,
     memory_index: u32,
 ) -> u32 {
-    let instance_contents = (&mut *vmctx).instance_contents();
+    let instance = (&mut *vmctx).instance();
     let memory_index = DefinedMemoryIndex::from_u32(memory_index);
 
-    instance_contents
+    instance
         .memory_grow(memory_index, delta)
         .unwrap_or(u32::max_value())
 }
@@ -109,10 +109,10 @@ pub unsafe extern "C" fn wasmtime_imported_memory32_grow(
     delta: u32,
     memory_index: u32,
 ) -> u32 {
-    let instance_contents = (&mut *vmctx).instance_contents();
+    let instance = (&mut *vmctx).instance();
     let memory_index = MemoryIndex::from_u32(memory_index);
 
-    instance_contents
+    instance
         .imported_memory_grow(memory_index, delta)
         .unwrap_or(u32::max_value())
 }
@@ -120,10 +120,10 @@ pub unsafe extern "C" fn wasmtime_imported_memory32_grow(
 /// Implementation of memory.size for locally-defined 32-bit memories.
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_memory32_size(vmctx: *mut VMContext, memory_index: u32) -> u32 {
-    let instance_contents = (&mut *vmctx).instance_contents();
+    let instance = (&mut *vmctx).instance();
     let memory_index = DefinedMemoryIndex::from_u32(memory_index);
 
-    instance_contents.memory_size(memory_index)
+    instance.memory_size(memory_index)
 }
 
 /// Implementation of memory.size for imported 32-bit memories.
@@ -132,8 +132,8 @@ pub unsafe extern "C" fn wasmtime_imported_memory32_size(
     vmctx: *mut VMContext,
     memory_index: u32,
 ) -> u32 {
-    let instance_contents = (&mut *vmctx).instance_contents();
+    let instance = (&mut *vmctx).instance();
     let memory_index = MemoryIndex::from_u32(memory_index);
 
-    instance_contents.imported_memory_size(memory_index)
+    instance.imported_memory_size(memory_index)
 }

--- a/lib/runtime/src/signalhandlers.rs
+++ b/lib/runtime/src/signalhandlers.rs
@@ -94,9 +94,9 @@ pub extern "C" fn wasmtime_init_finish(vmctx: &mut VMContext) {
         })
     }
 
-    let instance_contents = unsafe { vmctx.instance_contents() };
+    let instance = unsafe { vmctx.instance() };
     let have_signal_handlers = TRAP_CONTEXT.with(|cx| cx.borrow().haveSignalHandlers);
-    if !have_signal_handlers && instance_contents.needs_signal_handlers() {
+    if !have_signal_handlers && instance.needs_signal_handlers() {
         panic!("failed to install signal handlers");
     }
 }

--- a/lib/runtime/src/vmcontext.rs
+++ b/lib/runtime/src/vmcontext.rs
@@ -12,7 +12,7 @@ pub struct VMFunctionImport {
     /// A pointer to the imported function body.
     pub body: *const VMFunctionBody,
 
-    /// A pointer to the VMContext that owns the function.
+    /// A pointer to the `VMContext` that owns the function.
     pub vmctx: *mut VMContext,
 }
 
@@ -67,7 +67,7 @@ pub struct VMTableImport {
     /// A pointer to the imported table description.
     pub from: *mut VMTableDefinition,
 
-    /// A pointer to the VMContext that owns the table description.
+    /// A pointer to the `VMContext` that owns the table description.
     pub vmctx: *mut VMContext,
 }
 
@@ -104,7 +104,7 @@ pub struct VMMemoryImport {
     /// A pointer to the imported memory description.
     pub from: *mut VMMemoryDefinition,
 
-    /// A pointer to the VMContext that owns the memory description.
+    /// A pointer to the `VMContext` that owns the memory description.
     pub vmctx: *mut VMContext,
 }
 

--- a/lib/runtime/src/vmcontext.rs
+++ b/lib/runtime/src/vmcontext.rs
@@ -409,7 +409,7 @@ mod test_vmshared_signature_index {
 impl VMSharedSignatureIndex {
     /// Create a new `VMSharedSignatureIndex`.
     pub fn new(value: u32) -> Self {
-        Self(value)
+        VMSharedSignatureIndex(value)
     }
 }
 

--- a/lib/runtime/src/vmcontext.rs
+++ b/lib/runtime/src/vmcontext.rs
@@ -478,21 +478,20 @@ impl Default for VMCallerCheckedAnyfunc {
 pub struct VMContext {}
 
 impl VMContext {
-    /// Return a mutable reference to the associated `Instance`.
+    /// Return a mutable reference to the associated `InstanceContents`.
     ///
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `Instance`.
-    /// FIXME: make this pub(crate)?
+    /// be a `VMContext` allocated as part of an `InstanceContents`.
     #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn instance_contents(&mut self) -> &mut InstanceContents {
+    pub(crate) unsafe fn instance_contents(&mut self) -> &mut InstanceContents {
         &mut *((self as *mut Self as *mut u8).offset(-InstanceContents::vmctx_offset())
             as *mut InstanceContents)
     }
 
-    /// Return a mutable reference to the host state associated with `Instance`.
+    /// Return a mutable reference to the host state associated with `InstanceContents`.
     ///
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `Instance`.
+    /// be a `VMContext` allocated as part of an `InstanceContents`.
     pub unsafe fn host_state(&mut self) -> &mut Any {
         self.instance_contents().host_state()
     }

--- a/lib/runtime/src/vmcontext.rs
+++ b/lib/runtime/src/vmcontext.rs
@@ -409,7 +409,7 @@ mod test_vmshared_signature_index {
 impl VMSharedSignatureIndex {
     /// Create a new `VMSharedSignatureIndex`.
     pub fn new(value: u32) -> Self {
-        VMSharedSignatureIndex(value)
+        Self(value)
     }
 }
 

--- a/lib/runtime/src/vmcontext.rs
+++ b/lib/runtime/src/vmcontext.rs
@@ -1,7 +1,7 @@
 //! This file declares `VMContext` and several related structs which contain
 //! fields that compiled wasm code accesses directly.
 
-use crate::instance::InstanceContents;
+use crate::instance::Instance;
 use core::any::Any;
 use core::{ptr, u32};
 
@@ -478,26 +478,25 @@ impl Default for VMCallerCheckedAnyfunc {
 pub struct VMContext {}
 
 impl VMContext {
-    /// Return a mutable reference to the associated `InstanceContents`.
+    /// Return a mutable reference to the associated `Instance`.
     ///
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `InstanceContents`.
+    /// be a `VMContext` allocated as part of an `Instance`.
     #[allow(clippy::cast_ptr_alignment)]
-    pub(crate) unsafe fn instance_contents(&mut self) -> &mut InstanceContents {
-        &mut *((self as *mut Self as *mut u8).offset(-InstanceContents::vmctx_offset())
-            as *mut InstanceContents)
+    pub(crate) unsafe fn instance(&mut self) -> &mut Instance {
+        &mut *((self as *mut Self as *mut u8).offset(-Instance::vmctx_offset()) as *mut Instance)
     }
 
-    /// Return a mutable reference to the host state associated with `InstanceContents`.
+    /// Return a mutable reference to the host state associated with this `Instance`.
     ///
     /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `InstanceContents`.
+    /// be a `VMContext` allocated as part of an `Instance`.
     pub unsafe fn host_state(&mut self) -> &mut Any {
-        self.instance_contents().host_state()
+        self.instance().host_state()
     }
 
     /// Lookup an export in the global exports namespace.
     pub unsafe fn lookup_global_export(&mut self, field: &str) -> Option<crate::export::Export> {
-        self.instance_contents().lookup_global_export(field)
+        self.instance().lookup_global_export(field)
     }
 }

--- a/lib/wast/src/spectest.rs
+++ b/lib/wast/src/spectest.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use target_lexicon::HOST;
 use wasmtime_environ::{translate_signature, Export, MemoryPlan, Module, TablePlan};
 use wasmtime_jit::target_tunables;
-use wasmtime_runtime::{Imports, Instance, InstantiationError, VMContext, VMFunctionBody};
+use wasmtime_runtime::{Imports, InstanceHandle, InstantiationError, VMContext, VMFunctionBody};
 
 extern "C" fn spectest_print() {}
 
@@ -46,7 +46,7 @@ extern "C" fn spectest_print_f64_f64(_vmctx: &mut VMContext, x: f64, y: f64) {
 
 /// Return an instance implementing the "spectest" interface used in the
 /// spec testsuite.
-pub fn instantiate_spectest() -> Result<Instance, InstantiationError> {
+pub fn instantiate_spectest() -> Result<InstanceHandle, InstantiationError> {
     let call_conv = isa::CallConv::triple_default(&HOST);
     let pointer_type = types::Type::triple_pointer_type(&HOST);
     let mut module = Module::new();
@@ -216,7 +216,7 @@ pub fn instantiate_spectest() -> Result<Instance, InstantiationError> {
     let data_initializers = Vec::new();
     let signatures = PrimaryMap::new();
 
-    Instance::new(
+    InstanceHandle::new(
         Rc::new(module),
         Rc::new(RefCell::new(HashMap::new())),
         finished_functions.into_boxed_slice(),

--- a/lib/wast/src/wast.rs
+++ b/lib/wast/src/wast.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use std::{fmt, fs, io, str};
 use wabt::script::{Action, Command, CommandKind, ModuleBinary, ScriptParser, Value};
 use wasmtime_jit::{
-    ActionError, ActionOutcome, Compiler, Context, Instance, InstantiationError, RuntimeValue,
-    UnknownInstance,
+    ActionError, ActionOutcome, Compiler, Context, InstanceHandle, InstantiationError,
+    RuntimeValue, UnknownInstance,
 };
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
@@ -71,7 +71,7 @@ pub struct WastFileError {
 pub struct WastContext {
     /// Wast files have a concept of a "current" module, which is the most
     /// recently defined.
-    current: Option<Instance>,
+    current: Option<InstanceHandle>,
 
     context: Context,
 }
@@ -85,7 +85,10 @@ impl WastContext {
         }
     }
 
-    fn get_instance(&mut self, instance_name: Option<&str>) -> Result<&mut Instance, WastError> {
+    fn get_instance(
+        &mut self,
+        instance_name: Option<&str>,
+    ) -> Result<&mut InstanceHandle, WastError> {
         let instance = if let Some(instance_name) = instance_name {
             self.context
                 .get_instance(instance_name)

--- a/src/wasmtime.rs
+++ b/src/wasmtime.rs
@@ -132,8 +132,8 @@ fn main() {
     let mut context = Context::with_isa(isa);
 
     // Make spectest available by default.
-    context.instance(
-        Some("spectest".to_owned()),
+    context.name_instance(
+        "spectest".to_owned(),
         instantiate_spectest().expect("instantiating spectest"),
     );
 
@@ -155,14 +155,14 @@ fn handle_module(context: &mut Context, args: &Args, path: &Path) -> Result<(), 
     let data = read_wasm(path.to_path_buf())?;
 
     // Create a new `Instance` by compiling and instantiating a wasm module.
-    let index = context
+    let mut instance = context
         .instantiate_module(None, &data)
         .map_err(|e| e.to_string())?;
 
     // If a function to invoke was given, invoke it.
     if let Some(ref f) = args.flag_invoke {
         match context
-            .invoke_indexed(index, f, &[])
+            .invoke(&mut instance, f, &[])
             .map_err(|e| e.to_string())?
         {
             ActionOutcome::Returned { .. } => {}

--- a/src/wasmtime.rs
+++ b/src/wasmtime.rs
@@ -154,7 +154,7 @@ fn handle_module(context: &mut Context, args: &Args, path: &Path) -> Result<(), 
     // Read the wasm module binary.
     let data = read_wasm(path.to_path_buf())?;
 
-    // Create a new `Instance` by compiling and instantiating a wasm module.
+    // Compile and instantiating a wasm module.
     let mut instance = context
         .instantiate_module(None, &data)
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
This eliminates the awkward `InstanceIndex`, and moves to simple reference counting for instances. It also renames what was previously called `Instance` to `InstanceHandle` to reflect that it's just a reference-counting handle around what is now called an `Instance` (previously `InstanceContents`).
