### PR TITLE
Convert from docopt to structopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,7 @@ wasmtime-runtime = { path = "lib/runtime" }
 wasmtime-jit = { path = "lib/jit" }
 wasmtime-obj = { path = "lib/obj" }
 wasmtime-wast = { path = "lib/wast" }
-docopt = "1.0.1"
-serde = "1.0.75"
-serde_derive = "1.0.75"
+structopt = "0.2.15"
 faerie = "0.7.1"
 target-lexicon = { version = "0.2.0", default-features = false }
 pretty_env_logger = "0.3.0"


### PR DESCRIPTION
Closes https://github.com/CraneStation/wasmtime/issues/55.

Instead of direct `clap` integration I've decided to use [structopt](https://crates.io/crates/structopt) crate, which is basically `clap` with custom derives, for these reasons:

 * it helps to keep verbose enough clap configuration out of the code
 * it is similar to previously used `docopt` crate, which will ease further maintenance
 * hides arguments parsing into required types (no more manual conversions from `String` to `PathBuf`)

Here is a generated output example for `wasm2obj` binary:

```
$ cargo run --bin wasm2obj -- --help
wasm2obj 0.1.0
The Wasmtime Project Developers
Wasm to native object translation utility.

Takes a binary WebAssembly module into a native object file. The translation is dependent on the environment chosen. The
default is a dummy environment that produces placeholder values.

USAGE:
    wasm2obj [FLAGS] [OPTIONS] <FILE> -o <arg_output>

FLAGS:
    -g               
            generate debug information

    -h, --help       
            Prints help information

    -V, --version    
            Prints version information

OPTIONS:
    -o <arg_output>              
            output file

        --target <arg_target>    
            build for the target triple; default is the host machine

ARGS:
    <FILE>    
```

P.S. I've also noticed that `wast` binary declares `flag_function` argument, but not using it at all. Was not sure what to do with that, so leaved it as is.