### PR TITLE
Get wasmtime building on Windows.

### DIFF
--- a/wasmtime-runtime/signalhandlers/SignalHandlers.cpp
+++ b/wasmtime-runtime/signalhandlers/SignalHandlers.cpp
@@ -13,8 +13,10 @@
 #include <stdio.h>
 
 #if defined(_WIN32)
-# include <winternl.h>  // must include before util/Windows.h's `#undef`s
-# include "util/Windows.h"
+
+# include <windows.h>
+# include <winternl.h>
+
 #elif defined(USE_APPLE_MACH_PORTS)
 # include <mach/exc.h>
 # include <mach/mach.h>

--- a/wasmtime-runtime/src/lib.rs
+++ b/wasmtime-runtime/src/lib.rs
@@ -28,8 +28,6 @@ extern crate lazy_static;
 extern crate memoffset;
 #[macro_use]
 extern crate failure_derive;
-#[cfg(target_os = "windows")]
-extern crate winapi;
 
 mod export;
 mod imports;

--- a/wasmtime-runtime/src/mmap.rs
+++ b/wasmtime-runtime/src/mmap.rs
@@ -188,8 +188,8 @@ impl Mmap {
     #[cfg(target_os = "windows")]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
         use winapi::um::memoryapi::VirtualAlloc;
-        use winapi::um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_NOACCESS, PAGE_READWRITE};
-
+        use winapi::um::winnt::{MEM_COMMIT, PAGE_READWRITE};
+        use core::ffi::c_void;
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
@@ -197,7 +197,7 @@ impl Mmap {
         assert!(start < self.len - len);
 
         // Commit the accessible size.
-        if unsafe { VirtualAlloc(self.ptr.add(start), len, MEM_COMMIT, PAGE_READWRITE) }.is_null() {
+        if unsafe { VirtualAlloc(self.ptr.add(start) as *mut c_void, len, MEM_COMMIT, PAGE_READWRITE) }.is_null() {
             return Err(errno::errno().to_string());
         }
 

--- a/wasmtime-runtime/src/mmap.rs
+++ b/wasmtime-runtime/src/mmap.rs
@@ -187,9 +187,9 @@ impl Mmap {
     /// `self`'s reserved memory.
     #[cfg(target_os = "windows")]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
+        use core::ffi::c_void;
         use winapi::um::memoryapi::VirtualAlloc;
         use winapi::um::winnt::{MEM_COMMIT, PAGE_READWRITE};
-        use core::ffi::c_void;
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
@@ -197,7 +197,16 @@ impl Mmap {
         assert!(start < self.len - len);
 
         // Commit the accessible size.
-        if unsafe { VirtualAlloc(self.ptr.add(start) as *mut c_void, len, MEM_COMMIT, PAGE_READWRITE) }.is_null() {
+        if unsafe {
+            VirtualAlloc(
+                self.ptr.add(start) as *mut c_void,
+                len,
+                MEM_COMMIT,
+                PAGE_READWRITE,
+            )
+        }
+        .is_null()
+        {
             return Err(errno::errno().to_string());
         }
 


### PR DESCRIPTION
Requires LLVM binaries from http://releases.llvm.org/download.html at build time (bindgen).