### PR TITLE
Document the `git clone --recurse-submodules` requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ utility or as a library embedded in a larger application.
 Wasmtime passes the WebAssembly spec testsuite, and supports a new system
 API proposal called [WebAssembly System Interface], or WASI.
 
+Wasmtime includes a git submodule; in order to build it, it's necessary to
+obtain a full checkout, like this:
+```
+git clone --recurse-submodules https://github.com/CraneStation/wasmtime.git.
+```
+
 To build Wasmtime, install cmake and clang, and then build with cargo, such
 as with "cargo build --release". For information on installing clang, see
 [rust-bindgen's documentation](https://github.com/rust-lang/rust-bindgen/blob/master/book/src/requirements.md).


### PR DESCRIPTION
Currently, it's necessary to do this in order to obtain a lightbeam
checkout, in order to build wasmtime.

I'm very interested in learning about better ways to solve this problem.

This documents the steps to avoiding the problem in https://github.com/CraneStation/wasmtime/issues/96.
