### PR TITLE
Allow access to memory_index and grow on Instance

### DIFF
--- a/wasmtime-runtime/src/instance.rs
+++ b/wasmtime-runtime/src/instance.rs
@@ -520,8 +520,7 @@ impl Instance {
     }
 
     /// Return the memory index for the given `VMMemoryDefinition`.
-    /// FIXME: Should this be pub(crate)?
-    pub fn memory_index(&self, memory: &VMMemoryDefinition) -> DefinedMemoryIndex {
+    pub(crate) fn memory_index(&self, memory: &VMMemoryDefinition) -> DefinedMemoryIndex {
         let offsets = &self.offsets;
         let begin = unsafe {
             (&self.vmctx as *const VMContext as *const u8)
@@ -548,8 +547,7 @@ impl Instance {
     ///
     /// Returns `None` if memory can't be grown by the specified amount
     /// of pages.
-    /// FIXME: Should this be pub(crate)?
-    pub fn memory_grow(&mut self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
+    pub(crate) fn memory_grow(&mut self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
         let result = self
             .memories
             .get_mut(memory_index)
@@ -831,6 +829,19 @@ impl InstanceHandle {
     /// Return a reference to the custom state attached to this instance.
     pub fn host_state(&mut self) -> &mut Any {
         self.instance_mut().host_state()
+    }
+
+    /// Return the memory index for the given `VMMemoryDefinition` in this instance.
+    pub fn memory_index(&self, memory: &VMMemoryDefinition) -> DefinedMemoryIndex {
+        self.instance().memory_index(memory)
+    }
+
+    /// Grow memory in this instance by the specified amount of pages.
+    ///
+    /// Returns `None` if memory can't be grown by the specified amount
+    /// of pages.
+    pub fn memory_grow(&mut self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
+        self.instance_mut().memory_grow(memory_index, delta)
     }
 }
 

--- a/wasmtime-runtime/src/instance.rs
+++ b/wasmtime-runtime/src/instance.rs
@@ -547,7 +547,11 @@ impl Instance {
     ///
     /// Returns `None` if memory can't be grown by the specified amount
     /// of pages.
-    pub(crate) fn memory_grow(&mut self, memory_index: DefinedMemoryIndex, delta: u32) -> Option<u32> {
+    pub(crate) fn memory_grow(
+        &mut self,
+        memory_index: DefinedMemoryIndex,
+        delta: u32,
+    ) -> Option<u32> {
         let result = self
             .memories
             .get_mut(memory_index)


### PR DESCRIPTION
Changed `memory_grow` and `memory_index` in `Instance` to be `pub(crate)` and added the equivalent proxy methods to the `InstanceHandle` struct. This allows developers taking a dependency on wasmtime to grow an instance's linear memory. 

From my example:
```rust
let mem = module_instance.lookup(MEMORY_EXPORT_NAME);
if mem.is_some() {
    match mem.unwrap() {
        Export::Memory {
            definition,
            vmctx: _,
            memory: _,
        } => unsafe {
            module_instance
                .memory_grow(
                    module_instance.memory_index(&*definition),
                    bytes_to_pages((LAMBDA_PAYLOAD_SIZE_BYTES * 2) + LAMBDA_CONTEXT_SIZE_BYTES),
                )
                .ok_or_else(|| SimpleError::new("Could not grow memory size"))?;
        },
        _ => warn!("Memory export is not of type Memory"),
    };
}
```