### PR TITLE
Handle set-size rights correctly when truncating a file.

### DIFF
--- a/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
+++ b/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
@@ -1703,7 +1703,7 @@ __wasi_errno_t wasmtime_ssp_path_open(
   bool write =
       (rights_base & (__WASI_RIGHT_FD_DATASYNC | __WASI_RIGHT_FD_WRITE |
                       __WASI_RIGHT_FD_ALLOCATE |
-                      __WASI_RIGHT_PATH_FILESTAT_SET_SIZE)) != 0;
+                      __WASI_RIGHT_FD_FILESTAT_SET_SIZE)) != 0;
   int noflags = write ? read ? O_RDWR : O_WRONLY : O_RDONLY;
 
   // Which rights are needed on the directory file descriptor.
@@ -1721,7 +1721,7 @@ __wasi_errno_t wasmtime_ssp_path_open(
     noflags |= O_EXCL;
   if ((oflags & __WASI_O_TRUNC) != 0) {
     noflags |= O_TRUNC;
-    needed_inheriting |= __WASI_RIGHT_PATH_FILESTAT_SET_SIZE;
+    needed_base |= __WASI_RIGHT_PATH_FILESTAT_SET_SIZE;
   }
 
   // Convert file descriptor flags.


### PR DESCRIPTION
If a path_open call is requesting __WASI_RIGHT_FD_FILESTAT_SET_SIZE,
interpret that as a request for write privleges. If it is requesting
O_TRUNC, require __WASI_RIGHT_PATH_FILESTAT_SET_SIZE, since this is
a path operation rather than a FD operation.