### PR TITLE
Don't allow a preopened file descriptor to be renamed over.

### DIFF
--- a/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -564,6 +564,7 @@ __wasi_errno_t wasmtime_ssp_fd_read(
 __wasi_errno_t wasmtime_ssp_fd_renumber(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,
+    struct fd_prestats *prestats,
 #endif
     __wasi_fd_t from,
     __wasi_fd_t to

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -573,10 +573,11 @@ syscalls! {
 
         let vmctx = &mut *vmctx;
         let curfds = get_curfds(vmctx);
+        let prestats = get_prestats(vmctx);
         let from = decode_fd(from);
         let to = decode_fd(to);
 
-        let e = host::wasmtime_ssp_fd_renumber(curfds, from, to);
+        let e = host::wasmtime_ssp_fd_renumber(curfds, prestats, from, to);
 
         return_encoded_errno(e)
     }


### PR DESCRIPTION
This is consistent with fd_close's behavior, and is likely temporary
until other options are designed.