### PR TITLE
Add Rust impl of wasmtime_ssp_proc_exit

### DIFF
--- a/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -810,10 +810,6 @@ __wasi_errno_t wasmtime_ssp_poll_oneoff(
     size_t *nevents
 ) WASMTIME_SSP_SYSCALL_NAME(poll_oneoff) __attribute__((__warn_unused_result__));
 
-_Noreturn void wasmtime_ssp_proc_exit(
-    __wasi_exitcode_t rval
-) WASMTIME_SSP_SYSCALL_NAME(proc_exit);
-
 __wasi_errno_t wasmtime_ssp_proc_raise(
     __wasi_signal_t sig
 ) WASMTIME_SSP_SYSCALL_NAME(proc_raise) __attribute__((__warn_unused_result__));

--- a/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
+++ b/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
@@ -2530,12 +2530,6 @@ __wasi_errno_t wasmtime_ssp_poll_oneoff(
   return error;
 }
 
-void wasmtime_ssp_proc_exit(
-    __wasi_exitcode_t rval
-) {
-  _Exit(rval);
-}
-
 __wasi_errno_t wasmtime_ssp_proc_raise(
     __wasi_signal_t sig
 ) {

--- a/wasmtime-wasi/src/host_impls.rs
+++ b/wasmtime-wasi/src/host_impls.rs
@@ -1,0 +1,5 @@
+use super::wasm32;
+
+pub fn wasmtime_ssp_proc_exit(rval: wasm32::__wasi_exitcode_t) {
+    ::std::process::exit(rval as i32)
+}

--- a/wasmtime-wasi/src/lib.rs
+++ b/wasmtime-wasi/src/lib.rs
@@ -10,6 +10,7 @@ extern crate wasmtime_runtime;
 extern crate log;
 
 mod host;
+mod host_impls;
 mod instantiate;
 mod syscalls;
 mod translate;

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -2,6 +2,7 @@ use crate::host::{argv_environ_values, fd_prestats, fd_table};
 use crate::instantiate::WASIState;
 use cranelift_codegen::ir::types::{Type, I32, I64};
 use host;
+use host_impls;
 use std::{ptr, slice, str};
 use translate::*;
 use wasm32;
@@ -1383,7 +1384,7 @@ syscalls! {
 
         // TODO: Rather than call __wasi_proc_exit here, we should trigger a
         // stack unwind similar to a trap.
-        host::wasmtime_ssp_proc_exit(rval);
+        host_impls::wasmtime_ssp_proc_exit(rval);
     }
 
     pub unsafe extern "C" fn proc_raise(


### PR DESCRIPTION
Replaces C implementation of `wasmtime_ssp_proc_exit` with pure Rust implementation. This PR is the first one of a series addressing #120.