### PR TITLE
Replace {environ,size}_{sizes_get,get} C code with Rust

### DIFF
--- a/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -454,22 +454,6 @@ _Static_assert(_Alignof(__wasi_subscription_t) == 8, "non-wasi data layout");
 #define WASMTIME_SSP_SYSCALL_NAME(name)
 #endif
 
-__wasi_errno_t wasmtime_ssp_args_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct argv_environ_values *arg_environ,
-#endif
-    char **argv,
-    char *argv_buf
-) WASMTIME_SSP_SYSCALL_NAME(args_get) __attribute__((__warn_unused_result__));
-
-__wasi_errno_t wasmtime_ssp_args_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct argv_environ_values *arg_environ,
-#endif
-    size_t *argc,
-    size_t *argv_buf_size
-) WASMTIME_SSP_SYSCALL_NAME(args_sizes_get) __attribute__((__warn_unused_result__));
-
 __wasi_errno_t wasmtime_ssp_clock_res_get(
     __wasi_clockid_t clock_id,
     __wasi_timestamp_t *resolution
@@ -481,21 +465,13 @@ __wasi_errno_t wasmtime_ssp_clock_time_get(
     __wasi_timestamp_t *time
 ) WASMTIME_SSP_SYSCALL_NAME(clock_time_get) __attribute__((__warn_unused_result__));
 
-__wasi_errno_t wasmtime_ssp_environ_get(
+__wasi_errno_t wasmtime_ssp_fd_prestat_get(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct argv_environ_values *arg_environ,
+    struct fd_prestats *prestats,
 #endif
-    char **environ,
-    char *environ_buf
-) WASMTIME_SSP_SYSCALL_NAME(environ_get) __attribute__((__warn_unused_result__));
-
-__wasi_errno_t wasmtime_ssp_environ_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct argv_environ_values *arg_environ,
-#endif
-    size_t *environ_count,
-    size_t *environ_buf_size
-) WASMTIME_SSP_SYSCALL_NAME(environ_sizes_get) __attribute__((__warn_unused_result__));
+    __wasi_fd_t fd,
+    __wasi_prestat_t *buf
+) WASMTIME_SSP_SYSCALL_NAME(fd_prestat_get) __attribute__((__warn_unused_result__));
 
 __wasi_errno_t wasmtime_ssp_fd_prestat_dir_name(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)

--- a/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
+++ b/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
@@ -2656,60 +2656,6 @@ __wasi_errno_t wasmtime_ssp_sock_shutdown(
   return 0;
 }
 
-__wasi_errno_t wasmtime_ssp_args_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
-#endif
-  char **argv,
-  char *argv_buf
-) {
-  for (size_t i = 0; i < argv_environ->argc; ++i) {
-    argv[i] = argv_buf + (argv_environ->argv[i] - argv_environ->argv_buf);
-  }
-  argv[argv_environ->argc] = NULL;
-  memcpy(argv_buf, argv_environ->argv_buf, argv_environ->argv_buf_size);
-  return __WASI_ESUCCESS;
-}
-
-__wasi_errno_t wasmtime_ssp_args_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
-#endif
-  size_t *argc,
-  size_t *argv_buf_size
-) {
-  *argc = argv_environ->argc;
-  *argv_buf_size = argv_environ->argv_buf_size;
-  return __WASI_ESUCCESS;
-}
-
-__wasi_errno_t wasmtime_ssp_environ_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
-#endif
-  char **environ,
-  char *environ_buf
-) {
-  for (size_t i = 0; i < argv_environ->environ_count; ++i) {
-    environ[i] = environ_buf + (argv_environ->environ[i] - argv_environ->environ_buf);
-  }
-  environ[argv_environ->environ_count] = NULL;
-  memcpy(environ_buf, argv_environ->environ_buf, argv_environ->environ_buf_size);
-  return __WASI_ESUCCESS;
-}
-
-__wasi_errno_t wasmtime_ssp_environ_sizes_get(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-  struct argv_environ_values *argv_environ,
-#endif
-  size_t *environ_count,
-  size_t *environ_buf_size
-) {
-  *environ_count = argv_environ->environ_count;
-  *environ_buf_size = argv_environ->environ_buf_size;
-  return __WASI_ESUCCESS;
-}
-
 void argv_environ_init(struct argv_environ_values *argv_environ,
                        const size_t *argv_offsets, size_t argv_offsets_len,
                        const char *argv_buf, size_t argv_buf_len,


### PR DESCRIPTION
Caveats:
* Clobbers the WASMTIME_SSP_STATIC_CURFDS option; I'm not sure about the best way to handle conditionally changing the function signature, or whether it needs to stick around. The js-polyfill code that defines the macro appears to have the sizes_get/get functions stubbed out in WASIPolyfill, so maybe it's not a problem.
* sizes_get is only unsafe to match the original C code's function signature; I can update it to be safe if that makes more sense.
* Uses `wrapping_sub` instead of `offset_from` to compute pointer differences since `offset_from` is still marked nightly.