### PR TITLE
Add Rust impl of wasmtime_ssp_fd_prestat_dir_name

### DIFF
--- a/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
+++ b/wasmtime-wasi/sandboxed-system-primitives/include/wasmtime_ssp.h
@@ -497,15 +497,6 @@ __wasi_errno_t wasmtime_ssp_environ_sizes_get(
     size_t *environ_buf_size
 ) WASMTIME_SSP_SYSCALL_NAME(environ_sizes_get) __attribute__((__warn_unused_result__));
 
-__wasi_errno_t wasmtime_ssp_fd_prestat_dir_name(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_prestats *prestats,
-#endif
-    __wasi_fd_t fd,
-    char *path,
-    size_t path_len
-) WASMTIME_SSP_SYSCALL_NAME(fd_prestat_dir_name) __attribute__((__warn_unused_result__));
-
 __wasi_errno_t wasmtime_ssp_fd_close(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,

--- a/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
+++ b/wasmtime-wasi/sandboxed-system-primitives/src/posix.c
@@ -652,33 +652,6 @@ static __wasi_errno_t fd_table_insert_fd(
   return fd_table_insert(ft, fo, rights_base, rights_inheriting, out);
 }
 
-__wasi_errno_t wasmtime_ssp_fd_prestat_dir_name(
-#if !defined(WASMTIME_SSP_STATIC_CURFDS)
-    struct fd_prestats *prestats,
-#endif
-    __wasi_fd_t fd,
-    char *path,
-    size_t path_len
-) {
-  rwlock_rdlock(&prestats->lock);
-  struct fd_prestat *prestat;
-  __wasi_errno_t error = fd_prestats_get_entry(prestats, fd, &prestat);
-  if (error != 0) {
-    rwlock_unlock(&prestats->lock);
-    return error;
-  }
-  if (path_len != prestat->dir_name_len) {
-    rwlock_unlock(&prestats->lock);
-    return EINVAL;
-  }
-
-  memcpy(path, prestat->dir_name, path_len);
-
-  rwlock_unlock(&prestats->lock);
-
-  return 0;
-}
-
 __wasi_errno_t wasmtime_ssp_fd_close(
 #if !defined(WASMTIME_SSP_STATIC_CURFDS)
     struct fd_table *curfds,

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -404,7 +404,11 @@ syscalls! {
 
         trace!("     | (path,path_len)={:?}", str_for_trace(path, path_len));
 
-        let e = host::wasmtime_ssp_fd_prestat_dir_name(prestats, fd, path, path_len);
+        let e = host_impls::wasmtime_ssp_fd_prestat_dir_name(
+            &mut *prestats,
+            fd,
+            ::std::slice::from_raw_parts_mut(path, path_len),
+        );
 
         return_encoded_errno(e)
     }


### PR DESCRIPTION
This PR is a continuation of #130, and also addresses #120. It ports `wasmtime_ssp_fd_prestat_dir_name` from C to Rust, re-using the functions and mechanisms ported in #130 (i.e., things like `rwlock_rdlock!` macro or `fd_prestats_get_entry`).