### PR TITLE
js-polyfill: support Safari, which doesn't have instantiateStreaming

### DIFF
--- a/wasmtime-wasi/js-polyfill/polyfill.c
+++ b/wasmtime-wasi/js-polyfill/polyfill.c
@@ -26,7 +26,7 @@ void handleFiles(void) {
         let file = document.getElementById('input').files[0]; \
         let file_with_mime_type = file.slice(0, file.size, 'application/wasm'); \
         let response = new Response(file_with_mime_type); \
-        WebAssembly.instantiateStreaming(response, imports) \
+        wasi_instantiateStreaming(response, imports) \
         .then(obj => { \
             setInstance(obj.instance); \
             try { \

--- a/wasmtime-wasi/js-polyfill/wasi.js
+++ b/wasmtime-wasi/js-polyfill/wasi.js
@@ -31,6 +31,17 @@ function handleWASIExit(e) {
     }
 }
 
+// Safari doesn't have instantiateStreaming
+function wasi_instantiateStreaming(response, imports) {
+    if (WebAssembly && WebAssembly.instantiateStreaming) {
+        return WebAssembly.instantiateStreaming(response, imports);
+    }
+    return response.arrayBuffer()
+        .then(function(buffer) {
+            return WebAssembly.instantiate(buffer, imports);
+        });
+}
+
 // The current guest wasm instance.
 var currentInstance;
 


### PR DESCRIPTION
This fixes #134.