### PR TITLE
Update .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+# This file tells tools we use rustfmt. We use the default settings.


### PR DESCRIPTION
Explicitly document the intent for using the default rustfmt settings.