### PR TITLE
Ignore non-existent refs in the transformed DWARF

### DIFF
--- a/wasmtime-debug/src/transform.rs
+++ b/wasmtime-debug/src/transform.rs
@@ -568,8 +568,11 @@ where
     }
     for (die_id, attr_name, offset) in pending_die_refs {
         let die = comp_unit.get_mut(die_id);
-        let unit_id = die_ref_map[&offset];
-        die.set(attr_name, write::AttributeValue::ThisUnitEntryRef(unit_id));
+        // TODO we probably loosing DW_AT_abstract_origin and DW_AT_type references
+        // here, find out if we drop stuff we don't need to.
+        if let Some(unit_id) = die_ref_map.get(&offset) {
+            die.set(attr_name, write::AttributeValue::ThisUnitEntryRef(*unit_id));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
When used with the '-g' flag, wasmtime fails on more complex file. We don't have robust detection of non-used data so we just rely on DW_AT_ranges and DW_AT_low_pc attributes. It is possible we are loosing some of the info. But for now we want wasmtime not to fail -- the patch addresses the failure to "link" to the dropped entries.