### PR TITLE
Fix preopening dirs on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ errno = "0.2.4"
 [target.'cfg(unix)'.dependencies]
 wasmtime-wasi-c = { path = "wasmtime-wasi-c" }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
 [workspace]
 
 [features]


### PR DESCRIPTION
As it turns out, in order to get a dir handle on Windows in Rust, you need to 1) use `std::os::windows::fs::OpenOptionsExt`, and 2) apply `FILE_FLAG_BACKUP_SEMANTICS` as one of the extended attributes. This, according to the [docs](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-createfile2), will create a handle to an existing dir, while any attempt at trying to create a dir this way will result in failure, which is what we are after AFAICT.