### PR TITLE
Fix a compiler warning.

### DIFF
--- a/wasmtime-runtime/src/instance.rs
+++ b/wasmtime-runtime/src/instance.rs
@@ -466,11 +466,11 @@ impl Instance {
             // As a compatibility measure, if the module doesn't have a start
             // function but does have a _start function exported, call that.
             match start_export {
-                wasmtime_environ::Export::Function(func_index) => {
-                    let sig = &self.module.signatures[self.module.functions[*func_index]];
+                &wasmtime_environ::Export::Function(func_index) => {
+                    let sig = &self.module.signatures[self.module.functions[func_index]];
                     // No wasm params or returns; just the vmctx param.
                     if sig.params.len() == 1 && sig.returns.is_empty() {
-                        self.invoke_function(*func_index)
+                        self.invoke_function(func_index)
                     } else {
                         Ok(())
                     }
@@ -482,11 +482,11 @@ impl Instance {
             // start function or a _start function exported, but does have a main
             // function exported, call that.
             match main_export {
-                wasmtime_environ::Export::Function(func_index) => {
-                    let sig = &self.module.signatures[self.module.functions[*func_index]];
+                &wasmtime_environ::Export::Function(func_index) => {
+                    let sig = &self.module.signatures[self.module.functions[func_index]];
                     // No wasm params or returns; just the vmctx param.
                     if sig.params.len() == 1 && sig.returns.is_empty() {
-                        self.invoke_function(*func_index)
+                        self.invoke_function(func_index)
                     } else {
                         Ok(())
                     }


### PR DESCRIPTION
Fix the following warning from Rust 1.35:

```rust
warning: cannot borrow `*self` as mutable because it is also borrowed as immutable
   --> wasmtime-runtime/src/instance.rs:473:25
    |
465 |         } else if let Some(start_export) = self.module.exports.get("_start") {
    |                                            ----------- immutable borrow occurs here
...
473 |                         self.invoke_function(*func_index)
    |                         ^^^^                 ----------- immutable borrow later used here
    |                         |
    |                         mutable borrow occurs here
    |
    = note: #[warn(mutable_borrow_reservation_conflict)] on by default
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
```