### PR TITLE
Use preopen_dir handlers exposed in wasi-common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ wasmtime-jit = { path = "wasmtime-jit" }
 wasmtime-obj = { path = "wasmtime-obj" }
 wasmtime-wast = { path = "wasmtime-wast" }
 wasmtime-wasi = { path = "wasmtime-wasi" }
+wasi-common = { git = "https://github.com/CraneStation/wasi-common" }
 docopt = "1.0.1"
 serde = "1.0.75"
 serde_derive = "1.0.75"
@@ -44,9 +45,6 @@ errno = "0.2.4"
 
 [target.'cfg(unix)'.dependencies]
 wasmtime-wasi-c = { path = "wasmtime-wasi-c" }
-
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3"
 
 [workspace]
 


### PR DESCRIPTION
This PR depends on CraneStation/wasi-common#25, hence, before that one is merged, a CI failure is expected due to the dependence on functionality in `wasi-common` which hasn't made it to master yet.