### PR TITLE
Use `try_from` instead of the cast crate.

### DIFF
--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -16,7 +16,6 @@ cranelift-codegen = "0.30.0"
 cranelift-entity = "0.30.0"
 cranelift-wasm = "0.30.0"
 lightbeam = { path = "../lightbeam", optional = true }
-cast = { version = "0.2.2", default-features = false }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
 indexmap = "1.0.2"

--- a/wasmtime-environ/src/func_environ.rs
+++ b/wasmtime-environ/src/func_environ.rs
@@ -1,8 +1,8 @@
 use crate::module::{MemoryPlan, MemoryStyle, Module, TableStyle};
 use crate::vmoffsets::VMOffsets;
 use crate::WASM_PAGE_SIZE;
-use cast;
 use core::clone::Clone;
+use core::convert::TryFrom;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::*;
@@ -353,8 +353,8 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             let vmctx = self.vmctx(func);
             if let Some(def_index) = self.module.defined_table_index(index) {
                 let base_offset =
-                    cast::i32(self.offsets.vmctx_vmtable_definition_base(def_index)).unwrap();
-                let current_elements_offset = cast::i32(
+                    i32::try_from(self.offsets.vmctx_vmtable_definition_base(def_index)).unwrap();
+                let current_elements_offset = i32::try_from(
                     self.offsets
                         .vmctx_vmtable_definition_current_elements(def_index),
                 )
@@ -364,7 +364,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let from_offset = self.offsets.vmctx_vmtable_import_from(index);
                 let table = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
-                    offset: Offset32::new(cast::i32(from_offset).unwrap()),
+                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                     global_type: pointer_type,
                     readonly: true,
                 });
@@ -410,8 +410,8 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             let vmctx = self.vmctx(func);
             if let Some(def_index) = self.module.defined_memory_index(index) {
                 let base_offset =
-                    cast::i32(self.offsets.vmctx_vmmemory_definition_base(def_index)).unwrap();
-                let current_length_offset = cast::i32(
+                    i32::try_from(self.offsets.vmctx_vmmemory_definition_base(def_index)).unwrap();
+                let current_length_offset = i32::try_from(
                     self.offsets
                         .vmctx_vmmemory_definition_current_length(def_index),
                 )
@@ -421,7 +421,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
                 let memory = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
-                    offset: Offset32::new(cast::i32(from_offset).unwrap()),
+                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                     global_type: pointer_type,
                     readonly: true,
                 });
@@ -488,13 +488,14 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let (ptr, offset) = {
             let vmctx = self.vmctx(func);
             if let Some(def_index) = self.module.defined_global_index(index) {
-                let offset = cast::i32(self.offsets.vmctx_vmglobal_definition(def_index)).unwrap();
+                let offset =
+                    i32::try_from(self.offsets.vmctx_vmglobal_definition(def_index)).unwrap();
                 (vmctx, offset)
             } else {
                 let from_offset = self.offsets.vmctx_vmglobal_import_from(index);
                 let global = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
-                    offset: Offset32::new(cast::i32(from_offset).unwrap()),
+                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                     global_type: pointer_type,
                     readonly: true,
                 });
@@ -548,7 +549,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let vmctx = self.vmctx(pos.func);
                 let base = pos.ins().global_value(pointer_type, vmctx);
                 let offset =
-                    cast::i32(self.offsets.vmctx_vmshared_signature_id(sig_index)).unwrap();
+                    i32::try_from(self.offsets.vmctx_vmshared_signature_id(sig_index)).unwrap();
 
                 // Load the caller ID.
                 let mut mem_flags = ir::MemFlags::trusted();
@@ -627,12 +628,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
         // Load the callee address.
         let body_offset =
-            cast::i32(self.offsets.vmctx_vmfunction_import_body(callee_index)).unwrap();
+            i32::try_from(self.offsets.vmctx_vmfunction_import_body(callee_index)).unwrap();
         let func_addr = pos.ins().load(pointer_type, mem_flags, base, body_offset);
 
         // First append the callee vmctx address.
         let vmctx_offset =
-            cast::i32(self.offsets.vmctx_vmfunction_import_vmctx(callee_index)).unwrap();
+            i32::try_from(self.offsets.vmctx_vmfunction_import_vmctx(callee_index)).unwrap();
         let vmctx = pos.ins().load(pointer_type, mem_flags, base, vmctx_offset);
         real_call_args.push(vmctx);
 

--- a/wasmtime-environ/src/module_environ.rs
+++ b/wasmtime-environ/src/module_environ.rs
@@ -1,6 +1,7 @@
 use crate::func_environ::FuncEnvironment;
 use crate::module::{Export, MemoryPlan, Module, TableElements, TablePlan};
 use crate::tunables::Tunables;
+use core::convert::TryFrom;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{AbiParam, ArgumentPurpose};
 use cranelift_codegen::isa::TargetFrontendConfig;
@@ -93,7 +94,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result
             .module
             .signatures
-            .reserve_exact(cast::usize(num));
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_signature(&mut self, sig: ir::Signature) {
@@ -168,10 +169,13 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn reserve_func_types(&mut self, num: u32) {
-        self.result.module.functions.reserve_exact(cast::usize(num));
+        self.result
+            .module
+            .functions
+            .reserve_exact(usize::try_from(num).unwrap());
         self.result
             .function_body_inputs
-            .reserve_exact(cast::usize(num));
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_func_type(&mut self, sig_index: SignatureIndex) {
@@ -182,7 +186,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result
             .module
             .table_plans
-            .reserve_exact(cast::usize(num));
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_table(&mut self, table: Table) {
@@ -194,7 +198,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result
             .module
             .memory_plans
-            .reserve_exact(cast::usize(num));
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_memory(&mut self, memory: Memory) {
@@ -203,7 +207,10 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn reserve_globals(&mut self, num: u32) {
-        self.result.module.globals.reserve_exact(cast::usize(num));
+        self.result
+            .module
+            .globals
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_global(&mut self, global: Global) {
@@ -211,7 +218,10 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     }
 
     fn reserve_exports(&mut self, num: u32) {
-        self.result.module.exports.reserve(cast::usize(num));
+        self.result
+            .module
+            .exports
+            .reserve(usize::try_from(num).unwrap());
     }
 
     fn declare_func_export(&mut self, func_index: FuncIndex, name: &str) {
@@ -251,7 +261,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
         self.result
             .module
             .table_elements
-            .reserve_exact(cast::usize(num));
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_table_elements(
@@ -284,7 +294,7 @@ impl<'data> cranelift_wasm::ModuleEnvironment<'data> for ModuleEnvironment<'data
     fn reserve_data_initializers(&mut self, num: u32) {
         self.result
             .data_initializers
-            .reserve_exact(cast::usize(num));
+            .reserve_exact(usize::try_from(num).unwrap());
     }
 
     fn declare_data_initialization(

--- a/wasmtime-environ/src/vmoffsets.rs
+++ b/wasmtime-environ/src/vmoffsets.rs
@@ -2,7 +2,7 @@
 //! module.
 
 use crate::module::Module;
-use cast;
+use core::convert::TryFrom;
 use cranelift_codegen::ir;
 use cranelift_wasm::{
     DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, GlobalIndex, MemoryIndex,
@@ -11,11 +11,11 @@ use cranelift_wasm::{
 
 #[cfg(target_pointer_width = "32")]
 fn cast_to_u32(sz: usize) -> u32 {
-    cast::u32(sz)
+    u32::try_from(sz).unwrap()
 }
 #[cfg(target_pointer_width = "64")]
 fn cast_to_u32(sz: usize) -> u32 {
-    match cast::u32(sz) {
+    match u32::try_from(sz) {
         Ok(x) => x,
         Err(_) => panic!("overflow in cast from usize to u32"),
     }

--- a/wasmtime-runtime/Cargo.toml
+++ b/wasmtime-runtime/Cargo.toml
@@ -21,7 +21,6 @@ lazy_static = "1.2.0"
 libc = { version = "0.2.48", default-features = false }
 errno = "0.2.4"
 memoffset = "0.3.0"
-cast = { version = "0.2.2", default-features = false }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
 indexmap = "1.0.2"

--- a/wasmtime-runtime/src/instance.rs
+++ b/wasmtime-runtime/src/instance.rs
@@ -30,6 +30,7 @@ use indexmap;
 use std::borrow::ToOwned;
 use std::boxed::Box;
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 use std::rc::Rc;
 use std::string::{String, ToString};
 use wasmtime_environ::{DataInitializer, Module, TableElements, VMOffsets};
@@ -42,7 +43,7 @@ fn signature_id(
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmshared_signature_id(index)));
+            .add(usize::try_from(offsets.vmctx_vmshared_signature_id(index)).unwrap());
         *(ptr as *const VMSharedSignatureIndex)
     }
 }
@@ -55,7 +56,7 @@ fn imported_function<'vmctx>(
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmfunction_import(index)));
+            .add(usize::try_from(offsets.vmctx_vmfunction_import(index)).unwrap());
         &*(ptr as *const VMFunctionImport)
     }
 }
@@ -68,7 +69,7 @@ fn imported_table<'vmctx>(
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmtable_import(index)));
+            .add(usize::try_from(offsets.vmctx_vmtable_import(index)).unwrap());
         &*(ptr as *const VMTableImport)
     }
 }
@@ -81,7 +82,7 @@ fn imported_memory<'vmctx>(
     #[allow(clippy::cast_ptr_alignment)]
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmmemory_import(index)));
+            .add(usize::try_from(offsets.vmctx_vmmemory_import(index)).unwrap());
         &*(ptr as *const VMMemoryImport)
     }
 }
@@ -93,7 +94,7 @@ fn imported_global<'vmctx>(
 ) -> &'vmctx VMGlobalImport {
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmglobal_import(index)));
+            .add(usize::try_from(offsets.vmctx_vmglobal_import(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &*(ptr as *const VMGlobalImport)
     }
@@ -106,7 +107,7 @@ fn table<'vmctx>(
 ) -> &'vmctx VMTableDefinition {
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmtable_definition(index)));
+            .add(usize::try_from(offsets.vmctx_vmtable_definition(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &*(ptr as *const VMTableDefinition)
     }
@@ -119,7 +120,7 @@ fn table_mut<'vmctx>(
 ) -> &'vmctx mut VMTableDefinition {
     unsafe {
         let ptr = (vmctx as *mut VMContext as *mut u8)
-            .add(cast::usize(offsets.vmctx_vmtable_definition(index)));
+            .add(usize::try_from(offsets.vmctx_vmtable_definition(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &mut *(ptr as *mut VMTableDefinition)
     }
@@ -132,7 +133,7 @@ fn memory<'vmctx>(
 ) -> &'vmctx VMMemoryDefinition {
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmmemory_definition(index)));
+            .add(usize::try_from(offsets.vmctx_vmmemory_definition(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &*(ptr as *const VMMemoryDefinition)
     }
@@ -145,7 +146,7 @@ fn memory_mut<'vmctx>(
 ) -> &'vmctx mut VMMemoryDefinition {
     unsafe {
         let ptr = (vmctx as *mut VMContext as *mut u8)
-            .add(cast::usize(offsets.vmctx_vmmemory_definition(index)));
+            .add(usize::try_from(offsets.vmctx_vmmemory_definition(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &mut *(ptr as *mut VMMemoryDefinition)
     }
@@ -158,7 +159,7 @@ fn global<'vmctx>(
 ) -> &'vmctx VMGlobalDefinition {
     unsafe {
         let ptr = (vmctx as *const VMContext as *const u8)
-            .add(cast::usize(offsets.vmctx_vmglobal_definition(index)));
+            .add(usize::try_from(offsets.vmctx_vmglobal_definition(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &*(ptr as *const VMGlobalDefinition)
     }
@@ -171,7 +172,7 @@ fn global_mut<'vmctx>(
 ) -> &'vmctx mut VMGlobalDefinition {
     unsafe {
         let ptr = (vmctx as *mut VMContext as *mut u8)
-            .add(cast::usize(offsets.vmctx_vmglobal_definition(index)));
+            .add(usize::try_from(offsets.vmctx_vmglobal_definition(index)).unwrap());
         #[allow(clippy::cast_ptr_alignment)]
         &mut *(ptr as *mut VMGlobalDefinition)
     }
@@ -237,7 +238,7 @@ impl Instance {
     fn signature_ids_ptr(&mut self) -> *mut VMSharedSignatureIndex {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_signature_ids_begin()))
+                .add(usize::try_from(self.offsets.vmctx_signature_ids_begin()).unwrap())
                 as *mut VMSharedSignatureIndex
         }
     }
@@ -251,7 +252,7 @@ impl Instance {
     fn imported_functions_ptr(&mut self) -> *mut VMFunctionImport {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_imported_functions_begin()))
+                .add(usize::try_from(self.offsets.vmctx_imported_functions_begin()).unwrap())
                 as *mut VMFunctionImport
         }
     }
@@ -266,7 +267,7 @@ impl Instance {
     fn imported_tables_ptr(&mut self) -> *mut VMTableImport {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_imported_tables_begin()))
+                .add(usize::try_from(self.offsets.vmctx_imported_tables_begin()).unwrap())
                 as *mut VMTableImport
         }
     }
@@ -280,7 +281,7 @@ impl Instance {
     fn imported_memories_ptr(&mut self) -> *mut VMMemoryImport {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_imported_memories_begin()))
+                .add(usize::try_from(self.offsets.vmctx_imported_memories_begin()).unwrap())
                 as *mut VMMemoryImport
         }
     }
@@ -294,7 +295,7 @@ impl Instance {
     fn imported_globals_ptr(&mut self) -> *mut VMGlobalImport {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_imported_globals_begin()))
+                .add(usize::try_from(self.offsets.vmctx_imported_globals_begin()).unwrap())
                 as *mut VMGlobalImport
         }
     }
@@ -315,7 +316,7 @@ impl Instance {
     fn tables_ptr(&mut self) -> *mut VMTableDefinition {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_tables_begin()))
+                .add(usize::try_from(self.offsets.vmctx_tables_begin()).unwrap())
                 as *mut VMTableDefinition
         }
     }
@@ -334,7 +335,7 @@ impl Instance {
     fn memories_ptr(&mut self) -> *mut VMMemoryDefinition {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_memories_begin()))
+                .add(usize::try_from(self.offsets.vmctx_memories_begin()).unwrap())
                 as *mut VMMemoryDefinition
         }
     }
@@ -354,7 +355,7 @@ impl Instance {
     fn globals_ptr(&mut self) -> *mut VMGlobalDefinition {
         unsafe {
             (&mut self.vmctx as *mut VMContext as *mut u8)
-                .add(cast::usize(self.offsets.vmctx_globals_begin()))
+                .add(usize::try_from(self.offsets.vmctx_globals_begin()).unwrap())
                 as *mut VMGlobalDefinition
         }
     }
@@ -508,7 +509,7 @@ impl Instance {
         let offsets = &self.offsets;
         let begin = unsafe {
             (&self.vmctx as *const VMContext as *const u8)
-                .add(cast::usize(offsets.vmctx_tables_begin()))
+                .add(usize::try_from(offsets.vmctx_tables_begin()).unwrap())
         } as *const VMTableDefinition;
         let end: *const VMTableDefinition = table;
         // TODO: Use `offset_from` once it stablizes.
@@ -524,7 +525,7 @@ impl Instance {
         let offsets = &self.offsets;
         let begin = unsafe {
             (&self.vmctx as *const VMContext as *const u8)
-                .add(cast::usize(offsets.vmctx_memories_begin()))
+                .add(usize::try_from(offsets.vmctx_memories_begin()).unwrap())
         } as *const VMMemoryDefinition;
         let end: *const VMMemoryDefinition = memory;
         // TODO: Use `offset_from` once it stablizes.
@@ -653,7 +654,7 @@ impl InstanceHandle {
 
         let mut instance_mmap = Mmap::with_at_least(
             mem::size_of::<Instance>()
-                .checked_add(cast::usize(offsets.size_of_vmctx()))
+                .checked_add(usize::try_from(offsets.size_of_vmctx()).unwrap())
                 .unwrap(),
         )
         .map_err(InstantiationError::Resource)?;
@@ -990,7 +991,7 @@ fn get_memory_init_start(init: &DataInitializer<'_>, instance: &mut Instance) ->
         } else {
             instance.imported_global(base).from
         };
-        start += cast::usize(*unsafe { (*global).as_u32() });
+        start += usize::try_from(*unsafe { (*global).as_u32() }).unwrap();
     }
 
     start
@@ -1055,7 +1056,7 @@ fn get_table_init_start(init: &TableElements, instance: &mut Instance) -> usize 
         } else {
             instance.imported_global(base).from
         };
-        start += cast::usize(*unsafe { (*global).as_u32() });
+        start += usize::try_from(*unsafe { (*global).as_u32() }).unwrap();
     }
 
     start

--- a/wasmtime-runtime/src/memory.rs
+++ b/wasmtime-runtime/src/memory.rs
@@ -4,6 +4,7 @@
 
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;
+use std::convert::TryFrom;
 use std::string::String;
 use wasmtime_environ::{MemoryPlan, MemoryStyle, WASM_MAX_PAGES, WASM_PAGE_SIZE};
 
@@ -101,9 +102,9 @@ impl LinearMemory {
             return None;
         }
 
-        let delta_bytes = cast::usize(delta) * WASM_PAGE_SIZE as usize;
-        let prev_bytes = cast::usize(prev_pages) * WASM_PAGE_SIZE as usize;
-        let new_bytes = cast::usize(new_pages) * WASM_PAGE_SIZE as usize;
+        let delta_bytes = usize::try_from(delta).unwrap() * WASM_PAGE_SIZE as usize;
+        let prev_bytes = usize::try_from(prev_pages).unwrap() * WASM_PAGE_SIZE as usize;
+        let new_bytes = usize::try_from(new_pages).unwrap() * WASM_PAGE_SIZE as usize;
 
         if new_bytes > self.mmap.len() - self.offset_guard_size {
             // If the new size is within the declared maximum, but needs more memory than we

--- a/wasmtime-runtime/src/sig_registry.rs
+++ b/wasmtime-runtime/src/sig_registry.rs
@@ -2,9 +2,9 @@
 //! signature checking.
 
 use crate::vmcontext::VMSharedSignatureIndex;
-use cast;
 use cranelift_codegen::ir;
 use std::collections::{hash_map, HashMap};
+use std::convert::TryFrom;
 
 /// WebAssembly requires that the caller and callee signatures in an indirect
 /// call must match. To implement this efficiently, keep a registry of all
@@ -29,10 +29,7 @@ impl SignatureRegistry {
         match self.signature_hash.entry(sig.clone()) {
             hash_map::Entry::Occupied(entry) => *entry.get(),
             hash_map::Entry::Vacant(entry) => {
-                #[cfg(target_pointer_width = "32")]
-                let sig_id = VMSharedSignatureIndex::new(cast::u32(len));
-                #[cfg(target_pointer_width = "64")]
-                let sig_id = VMSharedSignatureIndex::new(cast::u32(len).unwrap());
+                let sig_id = VMSharedSignatureIndex::new(u32::try_from(len).unwrap());
                 entry.insert(sig_id);
                 sig_id
             }

--- a/wasmtime-wasi-c/Cargo.toml
+++ b/wasmtime-wasi-c/Cargo.toml
@@ -17,7 +17,6 @@ cranelift-codegen = "0.30.0"
 cranelift-entity = "0.30.0"
 cranelift-wasm = "0.30.0"
 target-lexicon = "0.3.0"
-cast = { version = "0.2.2", default-features = false }
 log = { version = "0.4.6", default-features = false }
 libc = "0.2.50"
 

--- a/wasmtime-wasi-c/src/lib.rs
+++ b/wasmtime-wasi-c/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate cast;
 extern crate cranelift_codegen;
 extern crate cranelift_entity;
 extern crate cranelift_wasm;

--- a/wasmtime-wasi-c/src/syscalls.rs
+++ b/wasmtime-wasi-c/src/syscalls.rs
@@ -2,6 +2,7 @@ use crate::host::{argv_environ_values, fd_prestats, fd_table};
 use crate::instantiate::WASIState;
 use cranelift_codegen::ir::types::{Type, I32, I64};
 use host;
+use std::convert::TryFrom;
 use std::{mem, ptr, slice, str};
 use translate::*;
 use wasm32;
@@ -170,11 +171,11 @@ syscalls! {
 
         let vmctx = &mut *vmctx;
         let argv_environ = get_argv_environ(vmctx);
-        let argc = match cast::u32((*argv_environ).argc) {
+        let argc = match u32::try_from((*argv_environ).argc) {
             Ok(argc) => argc,
             Err(_) => return wasm32::__WASI_ENOMEM,
         };
-        let argv_buf_size = match cast::u32((*argv_environ).argv_buf_size) {
+        let argv_buf_size = match u32::try_from((*argv_environ).argv_buf_size) {
             Ok(argc) => argc,
             Err(_) => return wasm32::__WASI_ENOMEM,
         };
@@ -307,11 +308,11 @@ syscalls! {
 
         let vmctx = &mut *vmctx;
         let argv_environ = get_argv_environ(vmctx);
-        let environ_count = match cast::u32((*argv_environ).environ_count) {
+        let environ_count = match u32::try_from((*argv_environ).environ_count) {
             Ok(host_environ_count) => host_environ_count,
             Err(_) => return wasm32::__WASI_ENOMEM,
         };
-        let environ_buf_size = match cast::u32((*argv_environ).environ_buf_size) {
+        let environ_buf_size = match u32::try_from((*argv_environ).environ_buf_size) {
             Ok(host_environ_buf_size) => host_environ_buf_size,
             Err(_) => return wasm32::__WASI_ENOMEM,
         };

--- a/wasmtime-wasi-c/src/translate.rs
+++ b/wasmtime-wasi-c/src/translate.rs
@@ -1,6 +1,5 @@
-use cast;
-use cast::From as _0;
 use host;
+use std::convert::TryFrom;
 use std::mem::{align_of, size_of, zeroed};
 use std::slice;
 use wasm32;
@@ -85,7 +84,7 @@ pub unsafe fn decode_slice_of<T>(
     ptr: wasm32::uintptr_t,
     len: wasm32::size_t,
 ) -> Result<(*mut T, usize), host::__wasi_errno_t> {
-    let len = cast::usize(len);
+    let len = usize::try_from(len).unwrap();
 
     let ptr = decode_ptr(
         vmctx,
@@ -98,7 +97,7 @@ pub unsafe fn decode_slice_of<T>(
 }
 
 pub fn encode_usize(len: usize) -> wasm32::size_t {
-    cast::u32(len).unwrap()
+    u32::try_from(len).unwrap()
 }
 
 pub fn encode_device(device: host::__wasi_device_t) -> wasm32::__wasi_device_t {
@@ -274,7 +273,7 @@ pub unsafe fn decode_ciovec(
     vmctx: &mut VMContext,
     ciovec: &wasm32::__wasi_ciovec_t,
 ) -> Result<host::__wasi_ciovec_t, host::__wasi_errno_t> {
-    let len = cast::usize(ciovec.buf_len);
+    let len = usize::try_from(ciovec.buf_len).unwrap();
     Ok(host::__wasi_ciovec_t {
         buf: decode_ptr(vmctx, ciovec.buf, len, 1)? as *const host::void,
         buf_len: len,
@@ -285,7 +284,7 @@ pub unsafe fn decode_iovec(
     vmctx: &mut VMContext,
     iovec: &wasm32::__wasi_iovec_t,
 ) -> Result<host::__wasi_iovec_t, host::__wasi_errno_t> {
-    let len = cast::usize(iovec.buf_len);
+    let len = usize::try_from(iovec.buf_len).unwrap();
     Ok(host::__wasi_iovec_t {
         buf: decode_ptr(vmctx, iovec.buf, len, 1)? as *mut host::void,
         buf_len: len,
@@ -416,7 +415,7 @@ pub unsafe fn encode_fd_byref(
     fd_ptr: wasm32::uintptr_t,
     fd: host::__wasi_fd_t,
 ) {
-    encode_pointee::<wasm32::__wasi_fd_t>(vmctx, fd_ptr, wasm32::size_t::cast(fd))
+    encode_pointee::<wasm32::__wasi_fd_t>(vmctx, fd_ptr, wasm32::size_t::try_from(fd).unwrap())
 }
 
 pub unsafe fn decode_timestamp_byref(
@@ -434,7 +433,7 @@ pub unsafe fn encode_timestamp_byref(
     encode_pointee::<wasm32::__wasi_timestamp_t>(
         vmctx,
         timestamp_ptr,
-        wasm32::__wasi_timestamp_t::cast(host_timestamp),
+        wasm32::__wasi_timestamp_t::try_from(host_timestamp).unwrap(),
     )
 }
 
@@ -453,7 +452,7 @@ pub unsafe fn encode_filesize_byref(
     encode_pointee::<wasm32::__wasi_filesize_t>(
         vmctx,
         filesize_ptr,
-        wasm32::__wasi_filesize_t::cast(host_filesize),
+        wasm32::__wasi_filesize_t::try_from(host_filesize).unwrap(),
     )
 }
 
@@ -472,7 +471,7 @@ pub unsafe fn encode_roflags_byref(
     encode_pointee::<wasm32::__wasi_roflags_t>(
         vmctx,
         roflags_ptr,
-        wasm32::__wasi_roflags_t::cast(host_roflags),
+        wasm32::__wasi_roflags_t::try_from(host_roflags).unwrap(),
     )
 }
 
@@ -488,7 +487,11 @@ pub unsafe fn encode_usize_byref(
     usize_ptr: wasm32::uintptr_t,
     host_usize: usize,
 ) {
-    encode_pointee::<wasm32::size_t>(vmctx, usize_ptr, wasm32::size_t::cast(host_usize).unwrap())
+    encode_pointee::<wasm32::size_t>(
+        vmctx,
+        usize_ptr,
+        wasm32::size_t::try_from(host_usize).unwrap(),
+    )
 }
 
 pub unsafe fn decode_prestat_byref(


### PR DESCRIPTION
`try_from` is stable now, so cast is unnecessary.
This closes #169