### PR TITLE
Fixes incorrect guest `fd` encoding

### DIFF
--- a/wasmtime-wasi-c/src/syscalls.rs
+++ b/wasmtime-wasi-c/src/syscalls.rs
@@ -956,10 +956,8 @@ syscalls! {
             &mut host_fd,
         );
 
-        if u32::from(e) == host::__WASI_ESUCCESS {
-            trace!("     | *fd={:?}", host_fd);
-            encode_fd_byref(vmctx, fd, host_fd);
-        }
+        trace!("     | *fd={:?}", host_fd);
+        encode_fd_byref(vmctx, fd, host_fd);
 
         return_encoded_errno(e)
     }


### PR DESCRIPTION
Surfaced when running [sunfishcode/misc-tests](https://github.com/sunfishcode/misc-tests). When trying to truncate the file without the `__WASI_RIGHT_PATH_FILESTAT_SET_SIZE` right, error `__WASI_ENOTCAPABLE` was correctly returned, however, the guest `fd` pointer was not encoded to -1 in that case. This commit fixes it by taking out the guest `fd` encoding out of the conditional branch which turns out obsolete.

To elaborate, before this fix, if everything was successful, `host_fd` with the resultant file descriptor value would be correctly encoded inside the `fd` pointer. However, if there was an error in `host::wasmtime_ssp_path_open` call, the `host_fd` would correctly store `wasm32::__wasi_fd_t::max_value()` (equivalent to -1) but `fd` pointer would be untouched due to the encoding operation being behind an if statement which would be triggered only when `path_open` was successful.