### PR TITLE
Export the `CodeMemory` structure from `wasmtime-jit`

### DIFF
--- a/wasmtime-jit/src/code_memory.rs
+++ b/wasmtime-jit/src/code_memory.rs
@@ -8,7 +8,7 @@ use std::vec::Vec;
 use wasmtime_runtime::{Mmap, VMFunctionBody};
 
 /// Memory manager for executable code.
-pub(crate) struct CodeMemory {
+pub struct CodeMemory {
     current: Mmap,
     mmaps: Vec<Mmap>,
     position: usize,

--- a/wasmtime-jit/src/lib.rs
+++ b/wasmtime-jit/src/lib.rs
@@ -50,6 +50,7 @@ mod resolver;
 mod target_tunables;
 
 pub use crate::action::{ActionError, ActionOutcome, RuntimeValue};
+pub use crate::code_memory::CodeMemory;
 pub use crate::compiler::Compiler;
 pub use crate::context::{Context, ContextError, UnknownInstance};
 pub use crate::instantiate::{instantiate, CompiledModule, SetupError};


### PR DESCRIPTION
When writing other wasmtime-like frontends this is a useful utility to
have! If it's only for intended usage that's also totally ok, I figured
this would in that case also serve a simultaneous question as to how
best solve the purpose it serves!