### PR TITLE
Update to cranelift 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ name = "wasm2obj"
 path = "src/wasm2obj.rs"
 
 [dependencies]
-cranelift-codegen = "0.30.0"
-cranelift-native = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-native = "0.32.0"
 wasmtime-debug = { path = "wasmtime-debug" }
 wasmtime-environ = { path = "wasmtime-environ" }
 wasmtime-runtime = { path = "wasmtime-runtime" }
@@ -36,8 +36,8 @@ wasi-common = { git = "https://github.com/CraneStation/wasi-common" }
 docopt = "1.0.1"
 serde = "1.0.75"
 serde_derive = "1.0.75"
-faerie = "0.9.1"
-target-lexicon = { version = "0.3.0", default-features = false }
+faerie = "0.10.1"
+target-lexicon = { version = "0.4.0", default-features = false }
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.1"
 wabt = "0.7"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,11 +11,11 @@ cargo-fuzz = true
 [dependencies]
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = "0.30.0"
-cranelift-wasm = "0.30.0"
-cranelift-native = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-wasm = "0.32.0"
+cranelift-native = "0.32.0"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-wasmparser = { version = "0.29.2", default-features = false }
+wasmparser = { version = "0.32.1", default-features = false }
 binaryen = "0.5.0"
 
 [features]

--- a/wasmtime-debug/Cargo.toml
+++ b/wasmtime-debug/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2018"
 
 [dependencies]
 gimli = "0.17.0"
-wasmparser = { version = "0.29.0" }
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
-faerie = "0.9.1"
+wasmparser = { version = "0.32.1" }
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
+faerie = "0.10.1"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
-target-lexicon = { version = "0.3.0", default-features = false }
+target-lexicon = { version = "0.4.0", default-features = false }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
 

--- a/wasmtime-debug/src/write_debuginfo.rs
+++ b/wasmtime-debug/src/write_debuginfo.rs
@@ -6,7 +6,7 @@ use gimli::write::{
 };
 use gimli::RunTimeEndian;
 
-use faerie::artifact::Decl;
+use faerie::artifact::{Decl, SectionKind};
 use faerie::*;
 
 struct DebugReloc {
@@ -21,7 +21,7 @@ macro_rules! decl_section {
         $artifact
             .declare_with(
                 SectionId::$section.name(),
-                Decl::debug_section(),
+                Decl::section(SectionKind::Debug),
                 $name.0.writer.into_vec(),
             )
             .unwrap();

--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
 lightbeam = { path = "../lightbeam", optional = true }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }

--- a/wasmtime-jit/Cargo.toml
+++ b/wasmtime-jit/Cargo.toml
@@ -12,19 +12,19 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
-cranelift-frontend = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
+cranelift-frontend = "0.32.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 wasmtime-runtime = { path = "../wasmtime-runtime", default-features = false }
 wasmtime-debug = { path = "../wasmtime-debug", default-features = false }
 region = "2.0.0"
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
-target-lexicon = { version = "0.3.0", default-features = false }
+target-lexicon = { version = "0.4.0", default-features = false }
 hashbrown = { version = "0.1.8", optional = true }
-wasmparser = "0.29.2"
+wasmparser = "0.32.1"
 
 [features]
 default = ["std"]

--- a/wasmtime-jit/src/context.rs
+++ b/wasmtime-jit/src/context.rs
@@ -84,6 +84,7 @@ impl Context {
                 enable_reference_types: false,
                 enable_bulk_memory: false,
                 enable_simd: false,
+                enable_multi_value: false,
             },
             mutable_global_imports: true,
         };

--- a/wasmtime-jit/src/instantiate.rs
+++ b/wasmtime-jit/src/instantiate.rs
@@ -77,7 +77,7 @@ impl<'data> RawCompiledModule<'data> {
             None
         };
 
-        let (allocated_functions, relocations, dbg_image) = compiler.compile(
+        let (allocated_functions, jt_offsets, relocations, dbg_image) = compiler.compile(
             &translation.module,
             translation.function_body_inputs,
             debug_data,
@@ -86,6 +86,7 @@ impl<'data> RawCompiledModule<'data> {
         let imports = link_module(
             &translation.module,
             &allocated_functions,
+            &jt_offsets,
             relocations,
             resolver,
         )

--- a/wasmtime-obj/Cargo.toml
+++ b/wasmtime-obj/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
 wasmtime-environ = { path = "../wasmtime-environ" }
-faerie = "0.9.1"
+faerie = "0.10.1"

--- a/wasmtime-obj/src/function.rs
+++ b/wasmtime-obj/src/function.rs
@@ -62,11 +62,11 @@ pub fn emit_functions(
         .expect("Missing enable_verifier setting");
 
     for (i, _function_relocs) in relocations.iter() {
-        let body = compilation.get(i);
+        let body = &compilation.get(i).body;
         let func_index = module.func_index(i);
         let string_name = format!("_wasm_function_{}", func_index.index());
 
-        obj.define(string_name, body.to_vec())
+        obj.define(string_name, body.clone())
             .map_err(|err| format!("{}", err))?;
     }
 

--- a/wasmtime-runtime/Cargo.toml
+++ b/wasmtime-runtime/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 region = "2.0.0"
 lazy_static = "1.2.0"

--- a/wasmtime-wasi-c/Cargo.toml
+++ b/wasmtime-wasi-c/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
-target-lexicon = "0.3.0"
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
+target-lexicon = "0.4.0"
 log = { version = "0.4.6", default-features = false }
 libc = "0.2.50"
 

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -14,10 +14,10 @@ wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasi-common = { git = "https://github.com/CraneStation/wasi-common" }
-cranelift-codegen = "0.30.0"
-cranelift-entity = "0.30.0"
-cranelift-wasm = "0.30.0"
-target-lexicon = "0.3.0"
+cranelift-codegen = "0.32.0"
+cranelift-entity = "0.32.0"
+cranelift-wasm = "0.32.0"
+target-lexicon = "0.4.0"
 log = { version = "0.4.6", default-features = false }
 
 [badges]

--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -12,15 +12,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.30.0"
-cranelift-native = "0.30.0"
-cranelift-wasm = "0.30.0"
-cranelift-entity = "0.30.0"
+cranelift-codegen = "0.32.0"
+cranelift-native = "0.32.0"
+cranelift-wasm = "0.32.0"
+cranelift-entity = "0.32.0"
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wabt = "0.7"
-target-lexicon = "0.3.0"
+target-lexicon = "0.4.0"
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
 


### PR DESCRIPTION
- [x] Update dependencies for cranelift-*, faerie, target-lexicon, wasmparser
- [x] Allow jump tables (WIP?)
- [x] Fix spec_testsuite::type_ test: due to https://github.com/yurydelendik/wasmparser.rs/pull/112
- [x] Update lightbeam dependencies (see https://github.com/CraneStation/lightbeam/pull/25)