### PR TITLE
Downgrade memoffset to 0.2.1.

### DIFF
--- a/wasmtime-runtime/Cargo.toml
+++ b/wasmtime-runtime/Cargo.toml
@@ -20,7 +20,7 @@ region = "2.0.0"
 lazy_static = "1.2.0"
 libc = { version = "0.2.48", default-features = false }
 errno = "0.2.4"
-memoffset = "0.3.0"
+memoffset = "0.2.1"
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
 indexmap = "1.0.2"


### PR DESCRIPTION
Version 0.3.0 was yanked from crates.io.