### PR TITLE
Print correct version of bin tools

### DIFF
--- a/src/wasm2obj.rs
+++ b/src/wasm2obj.rs
@@ -86,7 +86,7 @@ fn read_wasm_file(path: PathBuf) -> Result<Vec<u8>, io::Error> {
 }
 
 fn main() {
-	let version = env!("CARGO_PKG_VERSION");
+    let version = env!("CARGO_PKG_VERSION");
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)

--- a/src/wasm2obj.rs
+++ b/src/wasm2obj.rs
@@ -89,7 +89,7 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(String::from("0.0.0")))
+                .version(Some(String::from("0.1.0")))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());

--- a/src/wasm2obj.rs
+++ b/src/wasm2obj.rs
@@ -86,10 +86,11 @@ fn read_wasm_file(path: PathBuf) -> Result<Vec<u8>, io::Error> {
 }
 
 fn main() {
+	let version = env!("CARGO_PKG_VERSION");
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(String::from("0.1.0")))
+                .version(Some(String::from(version)))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());

--- a/src/wasmtime.rs
+++ b/src/wasmtime.rs
@@ -191,7 +191,7 @@ fn compute_environ(flag_env: &[String]) -> Vec<(String, String)> {
 }
 
 fn main() {
-	let version = env!("CARGO_PKG_VERSION");
+    let version = env!("CARGO_PKG_VERSION");
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)

--- a/src/wasmtime.rs
+++ b/src/wasmtime.rs
@@ -194,7 +194,7 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(String::from("0.0.0")))
+                .version(Some(String::from("0.1.0")))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());

--- a/src/wasmtime.rs
+++ b/src/wasmtime.rs
@@ -191,10 +191,11 @@ fn compute_environ(flag_env: &[String]) -> Vec<(String, String)> {
 }
 
 fn main() {
+	let version = env!("CARGO_PKG_VERSION");
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(String::from("0.1.0")))
+                .version(Some(String::from(version)))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());

--- a/src/wast.rs
+++ b/src/wast.rs
@@ -64,10 +64,11 @@ struct Args {
 }
 
 fn main() {
+	let version = env!("CARGO_PKG_VERSION");
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(String::from("0.1.0")))
+                .version(Some(String::from(version)))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());

--- a/src/wast.rs
+++ b/src/wast.rs
@@ -67,7 +67,7 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)
-                .version(Some(String::from("0.0.0")))
+                .version(Some(String::from("0.1.0")))
                 .deserialize()
         })
         .unwrap_or_else(|e| e.exit());

--- a/src/wast.rs
+++ b/src/wast.rs
@@ -64,7 +64,7 @@ struct Args {
 }
 
 fn main() {
-	let version = env!("CARGO_PKG_VERSION");
+    let version = env!("CARGO_PKG_VERSION");
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| {
             d.help(true)


### PR DESCRIPTION
Not something important. But if needed, I changed the version to the correct one specified in Cargo.toml. I use these tools for some testing and they print wrong version with --version. 
