### PR TITLE
Update wasmtime-wasi-c to cloudabi-utils 223dadc5.

### DIFF
--- a/wasmtime-wasi-c/sandboxed-system-primitives/src/README.md
+++ b/wasmtime-wasi-c/sandboxed-system-primitives/src/README.md
@@ -5,9 +5,9 @@ along with the accompanying LICENSE file from that repository.
 The modifications are marked with `WASMTIME_*` preprocessor macros.
 
 The files were copied at git revision
-be1ce21e1dded9c0c0a6ebe144cbea01cf44a874
+223dadc53248552db43e012c67ed08cf416a2b12
 which is dated
-Sun Jan 13 23:26:03 2019 +0100
+Tue Jun 25 17:22:07 2019 -0700
 .
 
 [libemulator]: https://github.com/NuxiNL/cloudabi-utils/tree/master/src/libemulator

--- a/wasmtime-wasi-c/sandboxed-system-primitives/src/posix.c
+++ b/wasmtime-wasi-c/sandboxed-system-primitives/src/posix.c
@@ -1880,7 +1880,7 @@ __wasi_errno_t wasmtime_ssp_fd_readdir(
   }
 
   *bufused = 0;
-  while (nbyte > 0) {
+  while (*bufused < nbyte) {
     // Read the next directory entry.
     errno = 0;
     struct dirent *de = readdir(dp);


### PR DESCRIPTION
We already had a forward-port of d5abd351d, so this just contains a minor and unobservable bug fix.
