### PR TITLE
Update to Cranelift 1.33 and require Rust 1.35.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
     - osx
 language: rust
 rust:
-    - 1.34.0
+    - 1.35.0
     - beta
     - nightly
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ name = "wasm2obj"
 path = "src/wasm2obj.rs"
 
 [dependencies]
-cranelift-codegen = "0.32.0"
-cranelift-native = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-native = "0.33.0"
 wasmtime-debug = { path = "wasmtime-debug" }
 wasmtime-environ = { path = "wasmtime-environ" }
 wasmtime-runtime = { path = "wasmtime-runtime" }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ utility or as a library embedded in a larger application.
 [![Travis Status](https://travis-ci.org/CraneStation/wasmtime.svg?branch=master)](https://travis-ci.org/CraneStation/wasmtime)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/vxvpt2plriy5s0mc?svg=true)](https://ci.appveyor.com/project/CraneStation/cranelift)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
-![Minimum rustc 1.34](https://img.shields.io/badge/rustc-1.34+-green.svg)
+![Minimum rustc 1.35](https://img.shields.io/badge/rustc-1.35+-green.svg)
 
 Wasmtime passes the WebAssembly spec testsuite, and supports a new system
 API proposal called [WebAssembly System Interface], or WASI.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,9 @@ cargo-fuzz = true
 [dependencies]
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = "0.32.0"
-cranelift-wasm = "0.32.0"
-cranelift-native = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-wasm = "0.33.0"
+cranelift-native = "0.33.0"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 wasmparser = { version = "0.32.1", default-features = false }
 binaryen = "0.5.0"

--- a/wasmtime-debug/Cargo.toml
+++ b/wasmtime-debug/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 [dependencies]
 gimli = "0.17.0"
 wasmparser = { version = "0.32.1" }
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
 faerie = "0.10.1"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 target-lexicon = { version = "0.4.0", default-features = false }

--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
 lightbeam = { path = "../lightbeam", optional = true }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }

--- a/wasmtime-jit/Cargo.toml
+++ b/wasmtime-jit/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
-cranelift-frontend = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
+cranelift-frontend = "0.33.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 wasmtime-runtime = { path = "../wasmtime-runtime", default-features = false }
 wasmtime-debug = { path = "../wasmtime-debug", default-features = false }

--- a/wasmtime-obj/Cargo.toml
+++ b/wasmtime-obj/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
 wasmtime-environ = { path = "../wasmtime-environ" }
 faerie = "0.10.1"

--- a/wasmtime-runtime/Cargo.toml
+++ b/wasmtime-runtime/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 region = "2.0.0"
 lazy_static = "1.2.0"

--- a/wasmtime-wasi-c/Cargo.toml
+++ b/wasmtime-wasi-c/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
 target-lexicon = "0.4.0"
 log = { version = "0.4.6", default-features = false }
 libc = "0.2.50"

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -14,9 +14,9 @@ wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasi-common = { git = "https://github.com/CraneStation/wasi-common" }
-cranelift-codegen = "0.32.0"
-cranelift-entity = "0.32.0"
-cranelift-wasm = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-entity = "0.33.0"
+cranelift-wasm = "0.33.0"
 target-lexicon = "0.4.0"
 log = { version = "0.4.6", default-features = false }
 

--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = "0.32.0"
-cranelift-native = "0.32.0"
-cranelift-wasm = "0.32.0"
-cranelift-entity = "0.32.0"
+cranelift-codegen = "0.33.0"
+cranelift-native = "0.33.0"
+cranelift-wasm = "0.33.0"
+cranelift-entity = "0.33.0"
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }


### PR DESCRIPTION
Cranelift requires Rust 1.35; update accordingly.