### PR TITLE
Rust 1.36, with wasm32-wasi support, is now stable!

### DIFF
--- a/docs/WASI-intro.md
+++ b/docs/WASI-intro.md
@@ -29,8 +29,8 @@ toolchains will be able to implement WASI as well!
 To install a WASI-enabled Rust toolchain:
 
 ```
-rustup target add wasm32-wasi --toolchain nightly
-cargo +nightly build --target wasm32-wasi
+rustup target add wasm32-wasi
+cargo build --target wasm32-wasi
 ```
 
 Until now, Rust's WebAssembly support has had two main options, the

--- a/docs/WASI-tutorial.md
+++ b/docs/WASI-tutorial.md
@@ -152,8 +152,8 @@ Let's put this source in the main file of our crate `src/main.rs`.
 In order to build it, we first need to install a WASI-enabled Rust toolchain:
 
 ```
-$ rustup target add wasm32-wasi --toolchain nightly
-$ cargo +nightly build --target wasm32-wasi
+$ rustup target add wasm32-wasi
+$ cargo build --target wasm32-wasi
 ```
 
 We should now have the WebAssembly module created in `target/wasm32-wasi/debug`:


### PR DESCRIPTION
Update the documentation accordingly!