### PR TITLE
Bump required Rust version to 1.36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
     - osx
 language: rust
 rust:
-    - 1.35.0
+    - 1.36.0
     - beta
     - nightly
 matrix:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ utility or as a library embedded in a larger application.
 [![Travis Status](https://travis-ci.org/CraneStation/wasmtime.svg?branch=master)](https://travis-ci.org/CraneStation/wasmtime)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/vxvpt2plriy5s0mc?svg=true)](https://ci.appveyor.com/project/CraneStation/cranelift)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
-![Minimum rustc 1.35](https://img.shields.io/badge/rustc-1.35+-green.svg)
+![Minimum rustc 1.36](https://img.shields.io/badge/rustc-1.36+-green.svg)
 
 Wasmtime passes the WebAssembly spec testsuite, and supports a new system
 API proposal called [WebAssembly System Interface], or WASI.


### PR DESCRIPTION
Transitively required due to the requirements of [wasi-common](https://github.com/cranestation/wasi-common).