### PR TITLE
Enable cranelift-codegen's new all-arch feature to maintain full architecture support by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,7 @@ members = [
 ]
 
 [features]
+# Enable all supported architectures by default.
+default = ["cranelift-codegen/all-arch"]
 lightbeam = ["wasmtime-environ/lightbeam", "wasmtime-jit/lightbeam"]
 wasi-c = ["wasmtime-wasi-c"]


### PR DESCRIPTION
This quick patch goes along with the [corresponding PR in Cranelift](https://github.com/CraneStation/cranelift/pull/853) adding the `all-arch` feature.

The changes in the linked PR will remove all architectural support by default, allowing dependent projects (such as Wasmtime) to specify exactly which architectures they want to support. In mainline Wasmtime's case, full architectural support is desired, so this patch will simply maintain existing functionality once the Cranelift changes are merged in.

Tagging @sunfishcode @npmccallum @steveeJ @alexcrichton for review.