### PR TITLE
Fix RelocationTarget::JumpTable handling in wasm2obj

### DIFF
--- a/wasmtime-obj/src/function.rs
+++ b/wasmtime-obj/src/function.rs
@@ -96,6 +96,9 @@ pub fn emit_functions(
                     })
                     .map_err(|err| format!("{}", err))?;
                 }
+                RelocationTarget::JumpTable(_, _) => {
+                    // ignore relocations for jump tables
+                }
                 _ => panic!("relocations target not supported yet: {:?}", r.reloc_target),
             };
         }


### PR DESCRIPTION
The wasm2obj may fail with:

```
thread 'main' panicked at 'relocations target not supported yet: JumpTable(FuncIndex(31), jt0)', wasmtime-obj/src/function.rs:102:22
```

The patch fixes that