### PR TITLE
dependencies: pin wasi-common to specific rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ wasmtime-obj = { path = "wasmtime-obj" }
 wasmtime-wast = { path = "wasmtime-wast" }
 wasmtime-wasi = { path = "wasmtime-wasi" }
 wasmtime-wasi-c = { path = "wasmtime-wasi-c", optional = true }
-wasi-common = { git = "https://github.com/CraneStation/wasi-common" }
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "c3994bf57b5d2f1f973b0e4e37bc385695aa4ed2"}
 docopt = "1.0.1"
 serde = "1.0.75"
 serde_derive = "1.0.75"

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-wasi-common = { git = "https://github.com/CraneStation/wasi-common" }
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "c3994bf57b5d2f1f973b0e4e37bc385695aa4ed2"}
 cranelift-codegen = "0.33.0"
 cranelift-entity = "0.33.0"
 cranelift-wasm = "0.33.0"


### PR DESCRIPTION
This removes the reliance on having a correct version of wasi-common in
the cache by chance ;-)

Fixes #197.