### PR TITLE
Fix compilation of wasmtime-environ from within wasmtime-jit.

### DIFF
--- a/wasmtime-debug/Cargo.toml
+++ b/wasmtime-debug/Cargo.toml
@@ -25,7 +25,7 @@ failure_derive = { version = "0.1.3", default-features = false }
 
 [features]
 default = ["std"]
-std = ["cranelift-codegen/std", "cranelift-wasm/std"]
+std = ["cranelift-codegen/std", "cranelift-wasm/std", "wasmtime-environ/std"]
 core = ["cranelift-codegen/core", "cranelift-wasm/core"]
 
 [badges]

--- a/wasmtime-jit/Cargo.toml
+++ b/wasmtime-jit/Cargo.toml
@@ -28,7 +28,7 @@ wasmparser = "0.32.1"
 
 [features]
 default = ["std"]
-std = ["cranelift-codegen/std", "cranelift-wasm/std"]
+std = ["cranelift-codegen/std", "cranelift-wasm/std", "wasmtime-environ/std"]
 core = ["hashbrown/nightly", "cranelift-codegen/core", "cranelift-wasm/core", "wasmtime-environ/core"]
 lightbeam = ["wasmtime-environ/lightbeam"]
 


### PR DESCRIPTION
Enable wasmtime-environ/std when wasmtime-jit's std feature is enabled.

Fixes #200.