### PR TITLE
Add dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+# See https://dependabot.com/docs/config-file/ for a reference.
+version: 1
+update_configs:
+  - package_manager: "rust:cargo"
+    directory: "/"
+    update_schedule: "live"
+    version_requirement_updates: "auto"
+    allowed_updates:
+    - match:
+        update_type: "all"


### PR DESCRIPTION
@tschneidereit following your suggestion and adding the configuration to the repo. The config corresponds to the settings that I've applied on the website.

Even though it's already enabled via the dependabot website, I think the repo is a better place to have this config. I don't know how dependabot responds to this configuration after the fact of being enabled. Let's find out.