### PR TITLE
Properly initialize file_per_thread_logger for rayon thread pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ file-per-thread-logger = "0.1.1"
 wabt = "0.7"
 libc = "0.2.50"
 errno = "0.2.4"
+rayon = "1.1"
 
 [workspace]
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,8 @@
 pub fn init_file_per_thread_logger() {
-    // There's a problem with borrow checker and static lifetimes across lambdas running
-    // in different threads, so we just use the global instead of function argument.
     use super::LOG_FILENAME_PREFIX;
 
     file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+
     // Extending behavior of default spawner:
     // https://docs.rs/rayon/1.1.0/rayon/struct.ThreadPoolBuilder.html#method.spawn_handler
     // Source code says DefaultSpawner is implementation detail and

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,28 @@
+pub fn init_file_per_thread_logger() {
+    // There's a problem with borrow checker and static lifetimes across lambdas running
+    // in different threads, so we just use the global instead of function argument.
+    use super::LOG_FILENAME_PREFIX;
+
+    file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+    // Extending behavior of default spawner:
+    // https://docs.rs/rayon/1.1.0/rayon/struct.ThreadPoolBuilder.html#method.spawn_handler
+    // Source code says DefaultSpawner is implementation detail and
+    // shouldn't be used directly.
+    rayon::ThreadPoolBuilder::new()
+        .spawn_handler(|thread| {
+            let mut b = std::thread::Builder::new();
+            if let Some(name) = thread.name() {
+                b = b.name(name.to_owned());
+            }
+            if let Some(stack_size) = thread.stack_size() {
+                b = b.stack_size(stack_size);
+            }
+            b.spawn(|| {
+                file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+                thread.run()
+            })?;
+            Ok(())
+        })
+        .build_global()
+        .unwrap();
+}

--- a/src/wasmtime.rs
+++ b/src/wasmtime.rs
@@ -37,7 +37,6 @@ use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
 use cranelift_native;
 use docopt::Docopt;
-use file_per_thread_logger;
 use pretty_env_logger;
 use std::error::Error;
 use std::ffi::OsStr;
@@ -55,6 +54,8 @@ use wasmtime_wast::instantiate_spectest;
 
 #[cfg(feature = "wasi-c")]
 use wasmtime_wasi_c::instantiate_wasi_c;
+
+mod utils;
 
 static LOG_FILENAME_PREFIX: &str = "wasmtime.dbg.";
 
@@ -203,7 +204,7 @@ fn main() {
     if args.flag_debug {
         pretty_env_logger::init();
     } else {
-        file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+        utils::init_file_per_thread_logger();
     }
 
     let isa_builder = cranelift_native::builder().unwrap_or_else(|_| {

--- a/src/wast.rs
+++ b/src/wast.rs
@@ -32,12 +32,13 @@ use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
 use cranelift_native;
 use docopt::Docopt;
-use file_per_thread_logger;
 use pretty_env_logger;
 use std::path::Path;
 use std::process;
 use wasmtime_jit::Compiler;
 use wasmtime_wast::WastContext;
+
+mod utils;
 
 static LOG_FILENAME_PREFIX: &str = "cranelift.dbg.";
 
@@ -76,7 +77,7 @@ fn main() {
     if args.flag_debug {
         pretty_env_logger::init();
     } else {
-        file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+        utils::init_file_per_thread_logger();
     }
 
     let isa_builder = cranelift_native::builder().unwrap_or_else(|_| {

--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -19,7 +19,7 @@ lightbeam = { path = "../lightbeam", optional = true }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
 indexmap = "1.0.2"
-rayon = "1.0"
+rayon = "1.1"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Cranelift compiler in wasmtime-environ [uses](https://github.com/CraneStation/wasmtime/blob/d27d190/wasmtime-environ/src/cranelift.rs#L133) rayon threads to parallelize compilation. It logs some information in those threads[1], but don't initialize the logger in them. According to the documentation, we [must](https://docs.rs/file-per-thread-logger/0.1.2/file_per_thread_logger/fn.initialize.html) do it.
[1] the upcoming cache system in #203 uses the logging system, too