### PR TITLE
Remove cranelift-native dependency from wasmtime-wast.

### DIFF
--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = "0.33.0"
-cranelift-native = "0.33.0"
 cranelift-wasm = "0.33.0"
 cranelift-entity = "0.33.0"
 wasmtime-jit = { path = "../wasmtime-jit" }


### PR DESCRIPTION
This just removes an unneeded dependency.