### PR TITLE
Downgrade wabt from 0.8 to 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ faerie = "0.10.1"
 target-lexicon = { version = "0.4.0", default-features = false }
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.1"
-wabt = "0.8"
+wabt = "0.7"
 libc = "0.2.50"
 errno = "0.2.4"
 rayon = "1.1"

--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-entity = "0.33.0"
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
-wabt = "0.8"
+wabt = "0.7"
 target-lexicon = "0.4.0"
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }


### PR DESCRIPTION
Even though this somehow passed on Travis on [the
PR](https://github.com/CraneStation/wasmtime/pull/209), it fails on Travis on master, and I can reproduce the failure.

The failure is on spec_testsuite/names.wast:

```
$ RUST_BACKTRACE=1 target/debug/wast spec_testsuite/names.wast
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: FromUtf8Error { bytes: [255], error: Utf8Error { valid_up_to: 0, error_len: Some(1) } }', src/libcore/result.rs:999:5
stack backtrace:
[...]
   9: core::result::Result<T,E>::unwrap
             at /rustc/a53f9df32fbb0b5f4382caaad8f1a46f36ea887c/src/libcore/result.rs:800
  10: wabt::script::jstring_to_rstring
             at [...]/.cargo/registry/src/github.com-1ecc6299db9ec823/wabt-0.8.0/src/script/mod.rs:261
  11: wabt::script::parse_action
             at [...]/.cargo/registry/src/github.com-1ecc6299db9ec823/wabt-0.8.0/src/script/mod.rs:274
  12: wabt::script::ScriptParser<F32,F64>::next
             at [...]/.cargo/registry/src/github.com-1ecc6299db9ec823/wabt-0.8.0/src/script/mod.rs:504
  13: wasmtime_wast::wast::WastContext::run_buffer
             at wasmtime-wast/src/wast.rs:202
  14: wasmtime_wast::wast::WastContext::run_file
             at wasmtime-wast/src/wast.rs:472
  15: wast::main
             at src/wast.rs:107
[...]
```