### PR TITLE
Enable SIMD instructions from the command line

### DIFF
--- a/wasmtime-jit/src/lib.rs
+++ b/wasmtime-jit/src/lib.rs
@@ -51,7 +51,7 @@ mod target_tunables;
 
 pub use crate::action::{ActionError, ActionOutcome, RuntimeValue};
 pub use crate::compiler::Compiler;
-pub use crate::context::{Context, ContextError, UnknownInstance};
+pub use crate::context::{Context, ContextError, Features, UnknownInstance};
 pub use crate::instantiate::{instantiate, CompiledModule, SetupError};
 pub use crate::link::link_module;
 pub use crate::namespace::Namespace;

--- a/wasmtime-wast/src/wast.rs
+++ b/wasmtime-wast/src/wast.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::{fmt, fs, io, str};
 use wabt::script::{Action, Command, CommandKind, ModuleBinary, ScriptParser, Value};
 use wasmtime_jit::{
-    ActionError, ActionOutcome, Compiler, Context, InstanceHandle, InstantiationError,
+    ActionError, ActionOutcome, Compiler, Context, Features, InstanceHandle, InstantiationError,
     RuntimeValue, UnknownInstance,
 };
 
@@ -82,6 +82,14 @@ impl WastContext {
         Self {
             current: None,
             context: Context::new(compiler),
+        }
+    }
+
+    /// Construct a new instance with the given features using the current `Context`
+    pub fn with_features(self, features: Features) -> Self {
+        Self {
+            context: self.context.with_features(features),
+            ..self
         }
     }
 


### PR DESCRIPTION
This change adds an `--enable-simd` flag to the binaries in this project. This allows the ISA `enable_simd` flag to be set and to configure the validation configuration used by wasmparser to allow SIMD instructions.