### PR TITLE
Cache compression

### DIFF
--- a/src/bin/wasm2obj.rs
+++ b/src/bin/wasm2obj.rs
@@ -63,7 +63,7 @@ The translation is dependent on the environment chosen.
 The default is a dummy environment that produces placeholder values.
 
 Usage:
-    wasm2obj [--target TARGET] [-dg] [--cache | --cache-dir=<cache_dir>] [--enable-simd] <file> -o <output>
+    wasm2obj [--target TARGET] [-dg] [--cache] [--cache-dir=<cache_dir>] [--cache-compression-level=<compr_level>] [--enable-simd] <file> -o <output>
     wasm2obj --help | --version
 
 Options:
@@ -74,6 +74,8 @@ Options:
     -c, --cache         enable caching system, use default cache directory
     --cache-dir=<cache_dir>
                         enable caching system, use specified cache directory
+    --cache-compression-level=<compr_level>
+                        enable caching system, use custom compression level for new cache, values 1-21
     --enable-simd       enable proposed SIMD instructions
     --version           print the Cranelift version
     -d, --debug         enable debug output on stderr/stdout
@@ -88,6 +90,7 @@ struct Args {
     flag_debug: bool,
     flag_cache: bool,
     flag_cache_dir: Option<String>,
+    flag_cache_compression_level: Option<i32>,
     flag_enable_simd: bool,
 }
 
@@ -115,8 +118,11 @@ fn main() {
     }
 
     cache_conf::init(
-        args.flag_cache || args.flag_cache_dir.is_some(),
+        args.flag_cache
+            || args.flag_cache_dir.is_some()
+            || args.flag_cache_compression_level.is_some(),
         args.flag_cache_dir.as_ref(),
+        args.flag_cache_compression_level,
     );
 
     let path = Path::new(&args.arg_file);

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -61,8 +61,8 @@ including calling the start function if one is present. Additional functions
 given with --invoke are then called.
 
 Usage:
-    wasmtime [-odg] [--enable-simd] [--wasi-c] [--cache | --cache-dir=<cache_dir>] [--preload=<wasm>...] [--env=<env>...] [--dir=<dir>...] [--mapdir=<mapping>...] <file> [<arg>...]
-    wasmtime [-odg] [--enable-simd] [--wasi-c] [--cache | --cache-dir=<cache_dir>] [--preload=<wasm>...] [--env=<env>...] [--dir=<dir>...] [--mapdir=<mapping>...] --invoke=<fn> <file> [<arg>...]
+    wasmtime [-odg] [--enable-simd] [--wasi-c] [--cache] [--cache-dir=<cache_dir>] [--cache-compression-level=<compr_level>] [--preload=<wasm>...] [--env=<env>...] [--dir=<dir>...] [--mapdir=<mapping>...] <file> [<arg>...]
+    wasmtime [-odg] [--enable-simd] [--wasi-c] [--cache] [--cache-dir=<cache_dir>] [--cache-compression-level=<compr_level>] [--env=<env>...] [--dir=<dir>...] [--mapdir=<mapping>...] --invoke=<fn> <file> [<arg>...]
     wasmtime --help | --version
 
 Options:
@@ -71,6 +71,8 @@ Options:
     -c, --cache         enable caching system, use default cache directory
     --cache-dir=<cache_dir>
                         enable caching system, use specified cache directory
+    --cache-compression-level=<compr_level>
+                        enable caching system, use custom compression level for new cache, values 1-21
     -g                  generate debug information
     -d, --debug         enable debug output on stderr/stdout
     --enable-simd       enable proposed SIMD instructions
@@ -91,6 +93,7 @@ struct Args {
     flag_optimize: bool,
     flag_cache: bool,
     flag_cache_dir: Option<String>,
+    flag_cache_compression_level: Option<i32>,
     flag_debug: bool,
     flag_g: bool,
     flag_enable_simd: bool,
@@ -215,8 +218,11 @@ fn rmain() -> Result<(), Error> {
     }
 
     cache_conf::init(
-        args.flag_cache || args.flag_cache_dir.is_some(),
+        args.flag_cache
+            || args.flag_cache_dir.is_some()
+            || args.flag_cache_compression_level.is_some(),
         args.flag_cache_dir.as_ref(),
+        args.flag_cache_compression_level,
     );
 
     let isa_builder = cranelift_native::builder()

--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -41,7 +41,7 @@ const USAGE: &str = "
 Wast test runner.
 
 Usage:
-    wast [-do] [--enable-simd] [--cache | --cache-dir=<cache_dir>] <file>...
+    wast [-do] [--enable-simd] [--cache] [--cache-dir=<cache_dir>] [--cache-compression-level=<compr_level>] <file>...
     wast --help | --version
 
 Options:
@@ -51,6 +51,8 @@ Options:
     -c, --cache         enable caching system, use default cache directory
     --cache-dir=<cache_dir>
                         enable caching system, use specified cache directory
+    --cache-compression-level=<compr_level>
+                        enable caching system, use custom compression level for new cache, values 1-21
     -d, --debug         enable debug output on stderr/stdout
     --enable-simd       enable proposed SIMD instructions
 ";
@@ -63,6 +65,7 @@ struct Args {
     flag_optimize: bool,
     flag_cache: bool,
     flag_cache_dir: Option<String>,
+    flag_cache_compression_level: Option<i32>,
     flag_enable_simd: bool,
 }
 
@@ -83,8 +86,11 @@ fn main() {
     }
 
     cache_conf::init(
-        args.flag_cache || args.flag_cache_dir.is_some(),
+        args.flag_cache
+            || args.flag_cache_dir.is_some()
+            || args.flag_cache_compression_level.is_some(),
         args.flag_cache_dir.as_ref(),
+        args.flag_cache_compression_level,
     );
 
     let isa_builder = cranelift_native::builder().unwrap_or_else(|_| {

--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -28,6 +28,7 @@ bincode = "1.1.4"
 lazy_static = "1.3.0"
 spin = "0.5.0"
 log = { version = "0.4.8", default-features = false }
+zstd = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/wasmtime-environ/src/cache/tests.rs
+++ b/wasmtime-environ/src/cache/tests.rs
@@ -26,13 +26,15 @@ use tempfile;
 fn test_write_read_cache() {
     pretty_env_logger::init();
     let dir = tempfile::tempdir().expect("Can't create temporary directory");
-    conf::init(true, Some(dir.path()));
+    let compression_level = 5;
+    conf::init(true, Some(dir.path()), Some(compression_level));
     assert!(conf::cache_enabled());
     // assumption: config init creates cache directory and returns canonicalized path
     assert_eq!(
         *conf::cache_directory(),
         fs::canonicalize(dir.path()).unwrap()
     );
+    assert_eq!(conf::compression_level(), compression_level);
 
     let mut rng = SmallRng::from_seed([
         0x42, 0x04, 0xF3, 0x44, 0x11, 0x22, 0x33, 0x44, 0x67, 0x68, 0xFF, 0x00, 0x44, 0x23, 0x7F,

--- a/wasmtime-environ/tests/cache_fail_calling_init_twice.rs
+++ b/wasmtime-environ/tests/cache_fail_calling_init_twice.rs
@@ -5,6 +5,6 @@ use wasmtime_environ::cache_conf;
 #[should_panic]
 fn test_fail_calling_init_twice() {
     let dir = tempfile::tempdir().expect("Can't create temporary directory");
-    cache_conf::init(true, Some(dir.path()));
-    cache_conf::init(true, Some(dir.path()));
+    cache_conf::init(true, Some(dir.path()), Some(5));
+    cache_conf::init(true, Some(dir.path()), Some(5));
 }


### PR DESCRIPTION
Based on #223. Some initial implementation of compression for cache system.

Things to discuss:
- configuring compression level - I have temporarily added command line option for it, but it looks like too many details. It'd be probably better to have some performance presets for wasmtime (mentioned in https://github.com/CraneStation/wasmtime/issues/199),
- compression algorithm, currently using zstd
  * I preferred using official implementation with Rust bindings rather than some custom implementation; currently we require cmake and clang anyway, but we will probably want to not depend on them in future,
  * I did a quick research on different algorithms and other good choice could be lzma2. Anyway, it's hard to compare usage of specific algorithms without good benchmarks on our specific use case. I just do some quick test runs for having an approximated comparison.