### PR TITLE
Add stubs for constant relocation in RelocSink

### DIFF
--- a/wasmtime-environ/src/cranelift.rs
+++ b/wasmtime-environ/src/cranelift.rs
@@ -72,6 +72,17 @@ impl binemit::RelocSink for RelocSink {
             addend,
         });
     }
+
+    fn reloc_constant(
+        &mut self,
+        _code_offset: binemit::CodeOffset,
+        _reloc: binemit::Reloc,
+        _constant_offset: ir::ConstantOffset,
+    ) {
+        // Do nothing for now: cranelift emits constant data after the function code and also emits
+        // function code with correct relative offsets to the constant data.
+    }
+
     fn reloc_jt(&mut self, offset: binemit::CodeOffset, reloc: binemit::Reloc, jt: ir::JumpTable) {
         self.func_relocs.push(Relocation {
             reloc,

--- a/wasmtime-jit/src/compiler.rs
+++ b/wasmtime-jit/src/compiler.rs
@@ -330,6 +330,14 @@ impl binemit::RelocSink for RelocSink {
     ) {
         panic!("trampoline compilation should not produce external symbol relocs");
     }
+    fn reloc_constant(
+        &mut self,
+        _code_offset: binemit::CodeOffset,
+        _reloc: binemit::Reloc,
+        _constant_offset: ir::ConstantOffset,
+    ) {
+        panic!("trampoline compilation should not produce constant relocs");
+    }
     fn reloc_jt(
         &mut self,
         _offset: binemit::CodeOffset,


### PR DESCRIPTION
As discussed in https://github.com/CraneStation/cranelift/pull/868#issuecomment-517042737, changes related to relocating constants alter the `RelocSink` API. This patch adds the new `RelocSink::reloc_constant` method in wasmtime so that it will continue to build but does not yet implement them.