### PR TITLE
Publish release bundles to CraneStation/wasmtime

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -216,7 +216,7 @@ jobs:
   - task: GitHubRelease@0
     inputs:
       gitHubConnection: 'tschneidereit-releases'
-      repositoryName: 'tschneidereit/wasmtime'
+      repositoryName: 'cranestation/wasmtime'
       action: 'edit'
       target: '$(Build.SourceVersion)'
       tagSource: 'manual'
@@ -229,7 +229,7 @@ jobs:
   - task: GitHubRelease@0
     inputs:
       gitHubConnection: 'tschneidereit-releases'
-      repositoryName: 'tschneidereit/wasmtime'
+      repositoryName: 'cranestation/wasmtime'
       action: 'edit'
       target: '$(Build.SourceVersion)'
       tag: 'master'


### PR DESCRIPTION
Releases work just fine, but should go to the right repository :)