### PR TITLE
Rename "master" release to "dev"

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -156,8 +156,8 @@ jobs:
       displayName: Set tag name
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     - bash: |
-        echo "##vso[task.setvariable variable=tagName;]master"
-      displayName: Set tag name to "master"
+        echo "##vso[task.setvariable variable=tagName;]dev"
+      displayName: Set tag name to "dev"
       condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
     - bash: |
@@ -232,7 +232,7 @@ jobs:
       repositoryName: 'cranestation/wasmtime'
       action: 'edit'
       target: '$(Build.SourceVersion)'
-      tag: 'master'
+      tag: 'dev'
       title: 'Latest CI build'
       assets: '$(Build.ArtifactStagingDirectory)/**'
       isDraft: false


### PR DESCRIPTION
"master" is just really not a great word to use here. What's more, it's also not particularly self-explanatory, so let's change it to "dev", which I hope to be more so.

This affects both the git tag used and the file names for bundles.