### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET for macOS releases

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -99,6 +99,7 @@ jobs:
         imageName: 'ubuntu-16.04'
       mac:
         imageName: 'macos-10.14'
+        MACOSX_DEPLOYMENT_TARGET: 10.9
 
   variables:
     toolchain: stable

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -99,6 +99,10 @@ jobs:
         imageName: 'ubuntu-16.04'
       mac:
         imageName: 'macos-10.14'
+        # Lower the deployment target from our build image in an attempt to
+        # build more portable binaries that run on older releases. Note that
+        # 10.9 here is arbitrarily chosen and just happens to be the lowest that
+        # works at this time. Raising this is probably fine.
         MACOSX_DEPLOYMENT_TARGET: 10.9
 
   variables:


### PR DESCRIPTION
This is an effort to ideally produce "more portable" binaries for the
releases we publish to GitHub. Currently the way macOS works is that
you're generally only guaranteed to work on the same platform you built
on and later (although it may sometimes work on older platforms). By
configuring this environment variable it should be possible to lower the
binary compatibility requirement, allowing running binaries on older OS
releases than the build machine is running.

I've chosen 10.9 here since it seems to be the lowest that "just works",
but there's no particular reason other than that for choosing this. Rust
itself chooses 10.8 (I think) for the compiler and 10.7 for the standard
library. This decision is largely driven by the C++ code from wabt-sys
which has more requirements about binary compatibility than Rust code
does.

Note that I don't actually have older macOS machines to test on as well,
but I can at least confirm that this does affect the build process!