### PR TITLE
Compile Windows releases with a static CRT

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -95,6 +95,9 @@ jobs:
     matrix:
       windows:
         imageName: 'vs2017-win2016'
+        # Statically link against msvcrt to produce slightly more portable
+        # binaries on Windows by reducing our binary compatibility requirements.
+        RUSTFLAGS: -Ctarget-feature=+crt-static
       linux:
         imageName: 'ubuntu-16.04'
       mac:


### PR DESCRIPTION
This commit compiles all Rust code for the Windows release with
`-Ctarget-feature=+crt-static`. This is targeted at increasing the
binary compatibility of the binaries built to not rely on DLLs that
aren't always installed on Windows. Notably this statically links the C
runtime (notably used by the C++ code) and means that the final binary
relies on fewer dlls.

This in theory means that the binaries are only limited by the number of
APIs they use from Windows. Note that this also matches how we build
releases of Rust for MSVC.