### PR TITLE
Delete old GitHub 'dev' release when creating a new one

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -231,7 +231,6 @@ jobs:
     inputs:
       gitHubConnection: 'tschneidereit-releases'
       repositoryName: 'cranestation/wasmtime'
-      action: 'edit'
       target: '$(Build.SourceVersion)'
       tagSource: 'manual'
       tag: '$(tagName)'
@@ -244,7 +243,13 @@ jobs:
     inputs:
       gitHubConnection: 'tschneidereit-releases'
       repositoryName: 'cranestation/wasmtime'
-      action: 'edit'
+      action: 'delete'
+      tag: 'dev'
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  - task: GitHubRelease@0
+    inputs:
+      gitHubConnection: 'tschneidereit-releases'
+      repositoryName: 'cranestation/wasmtime'
       target: '$(Build.SourceVersion)'
       tag: 'dev'
       title: 'Latest CI build'


### PR DESCRIPTION
GitHub doesn't really support rolling releases from a branch, so we "simulate" those by updating the same tag, `dev` whenever changes are merged to `master`. Unfortunately updating a release doesn't actually update the commit the release is associated with (even though we specify the `target` input field).

This PR changes things such that we delete the old `dev` release before creating a new one under the same name.