### PR TITLE
Say "memory" instead of "__wasi_memory" in error messages.

### DIFF
--- a/wasmtime-wasi-c/src/translate.rs
+++ b/wasmtime-wasi-c/src/translate.rs
@@ -44,11 +44,11 @@ unsafe fn decode_ptr(
             // Ok, translate the address.
             Ok((((*definition).base as usize) + (ptr as usize)) as *mut u8)
         }
-        // No export named "__wasi_memory", or the export isn't a memory.
+        // No export named "memory", or the export isn't a memory.
         // FIXME: Is EINVAL the best code here?
         x => {
             println!(
-                "!!! no export named __wasi_memory, or the export isn't a mem: {:?}",
+                "!!! no export named \"memory\", or the export isn't a mem: {:?}",
                 x
             );
             Err(host::__WASI_EINVAL as host::__wasi_errno_t)

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -30,7 +30,7 @@ fn get_memory(vmctx: &mut VMContext) -> Result<&mut [u8], host::__wasi_errno_t> 
             )),
             x => {
                 println!(
-                    "!!! no export named __wasi_memory, or the export isn't a mem: {:?}",
+                    "!!! no export named \"memory\", or the export isn't a mem: {:?}",
                     x
                 );
                 Err(host::__WASI_EINVAL)


### PR DESCRIPTION
While the "__wasi_memory" name is something we considered, the name
currently being used for the memory exported to WASI is "memory", so
adjust the error message accordingly.