### PR TITLE
Conform to Cargo's conventional file layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,6 @@ categories = ["wasm"]
 repository = "https://github.com/CraneStation/wasmtime"
 edition = "2018"
 
-[[bin]]
-name = "wasmtime"
-path = "src/wasmtime.rs"
-
-[[bin]]
-name = "wast"
-path = "src/wast.rs"
-
-[[bin]]
-name = "wasm2obj"
-path = "src/wasm2obj.rs"
-
 [dependencies]
 cranelift-codegen = { version = "0.38.0", features = ["enable-serde"] }
 cranelift-native = "0.38.0"

--- a/src/bin/wasm2obj.rs
+++ b/src/bin/wasm2obj.rs
@@ -56,10 +56,6 @@ use wasmtime_environ::{
 };
 use wasmtime_obj::emit_module;
 
-mod utils;
-
-static LOG_FILENAME_PREFIX: &str = "wasm2obj.dbg.";
-
 const USAGE: &str = "
 Wasm to native object translation utility.
 Takes a binary WebAssembly module into a native object file.
@@ -112,7 +108,7 @@ fn main() {
     if args.flag_debug {
         pretty_env_logger::init();
     } else {
-        utils::init_file_per_thread_logger();
+        wasmtime::init_file_per_thread_logger("wasm2obj.dbg.");
     }
 
     cache_conf::init(args.flag_cache);

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -54,10 +54,6 @@ use wasmtime_wast::instantiate_spectest;
 #[cfg(feature = "wasi-c")]
 use wasmtime_wasi_c::instantiate_wasi_c;
 
-mod utils;
-
-static LOG_FILENAME_PREFIX: &str = "wasmtime.dbg.";
-
 const USAGE: &str = "
 Wasm runner.
 
@@ -207,7 +203,7 @@ fn main() {
     if args.flag_debug {
         pretty_env_logger::init();
     } else {
-        utils::init_file_per_thread_logger();
+        wasmtime::init_file_per_thread_logger("wasmtime.dbg.");
     }
 
     cache_conf::init(args.flag_cache);

--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -37,10 +37,6 @@ use wasmtime_environ::cache_conf;
 use wasmtime_jit::{Compiler, Features};
 use wasmtime_wast::WastContext;
 
-mod utils;
-
-static LOG_FILENAME_PREFIX: &str = "cranelift.dbg.";
-
 const USAGE: &str = "
 Wast test runner.
 
@@ -80,7 +76,7 @@ fn main() {
     if args.flag_debug {
         pretty_env_logger::init();
     } else {
-        utils::init_file_per_thread_logger();
+        wasmtime::init_file_per_thread_logger("cranelift.dbg.");
     }
 
     cache_conf::init(args.flag_cache);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,12 @@
-pub fn init_file_per_thread_logger() {
-    use super::LOG_FILENAME_PREFIX;
-
-    file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+pub fn init_file_per_thread_logger(prefix: &'static str) {
+    file_per_thread_logger::initialize(prefix);
 
     // Extending behavior of default spawner:
     // https://docs.rs/rayon/1.1.0/rayon/struct.ThreadPoolBuilder.html#method.spawn_handler
     // Source code says DefaultSpawner is implementation detail and
     // shouldn't be used directly.
     rayon::ThreadPoolBuilder::new()
-        .spawn_handler(|thread| {
+        .spawn_handler(move |thread| {
             let mut b = std::thread::Builder::new();
             if let Some(name) = thread.name() {
                 b = b.name(name.to_owned());
@@ -16,8 +14,8 @@ pub fn init_file_per_thread_logger() {
             if let Some(stack_size) = thread.stack_size() {
                 b = b.stack_size(stack_size);
             }
-            b.spawn(|| {
-                file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
+            b.spawn(move || {
+                file_per_thread_logger::initialize(prefix);
                 thread.run()
             })?;
             Ok(())


### PR DESCRIPTION
Move `src/*.rs` to `src/bin/*.rs` which are automatically inferred as
binaries and move `src/utils.rs` to `src/lib.rs` which is compiled as a
reusable library for each of the binaries we're building.