### PR TITLE
Add a default-run, so that "cargo run" doesn't need a --bin option.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://cranelift.readthedocs.io/"
 categories = ["wasm"]
 repository = "https://github.com/CraneStation/wasmtime"
 edition = "2018"
+default-run = "wasmtime"
 
 [dependencies]
 cranelift-codegen = { version = "0.38.0", features = ["enable-serde"] }


### PR DESCRIPTION
default-run is a new feature in Rust 1.37.