### PR TITLE
Rename release bundle for mac to replace 'apple' with 'macos'

### DIFF
--- a/ci/azure-build-release.yml
+++ b/ci/azure-build-release.yml
@@ -56,7 +56,7 @@ steps:
 - bash: echo "##vso[task.setvariable variable=basename;]wasmtime-$(tagName)-x86_64-windows"
   displayName: Configure basename var
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-- bash: echo "##vso[task.setvariable variable=basename;]wasmtime-$(tagName)-x86_64-apple"
+- bash: echo "##vso[task.setvariable variable=basename;]wasmtime-$(tagName)-x86_64-macos"
   displayName: Configure basename var
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 - bash: echo "##vso[task.setvariable variable=basename;]wasmtime-$(tagName)-x86_64-linux"


### PR DESCRIPTION
`apple` is really not a useful name here, when the release really is for macOS :)