### PR TITLE
Workaround a rounding difference in the strtof function in Centos 6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ errno = "0.2.4"
 rayon = "1.1"
 wasm-webidl-bindings = "0.4"
 
+# build.rs tests whether to enable a workaround for the libc strtof function.
+[target.'cfg(target_os = "linux")'.build-dependencies]
+libc = "0.2.60"
+
 [workspace]
 members = [
   "misc/wasmtime-rust",

--- a/build.rs
+++ b/build.rs
@@ -154,5 +154,27 @@ fn ignore(testsuite: &str, name: &str) -> bool {
             (_, _) => false,
         };
     }
+    if cfg!(target_os = "linux") {
+        // Test whether the libc correctly parses the following constant; if so,
+        // we can run the "const" test. If not, the "const" test will fail, since
+        // we use wabt to parse the tests and wabt uses strtof.
+        extern "C" {
+            pub fn strtof(s: *const libc::c_char, endp: *mut *mut libc::c_char) -> libc::c_float;
+        }
+        if unsafe {
+            strtof(
+                b"8.8817847263968443574e-16" as *const u8 as *const libc::c_char,
+                std::ptr::null_mut(),
+            )
+        }
+        .to_bits()
+            != 0x26800001
+        {
+            return match (testsuite, name) {
+                ("spec_testsuite", "const") => true,
+                (_, _) => false,
+            };
+        }
+    }
     false
 }

--- a/build.rs
+++ b/build.rs
@@ -154,7 +154,9 @@ fn ignore(testsuite: &str, name: &str) -> bool {
             (_, _) => false,
         };
     }
-    if cfg!(target_os = "linux") {
+
+    #[cfg(target_os = "linux")]
+    {
         // Test whether the libc correctly parses the following constant; if so,
         // we can run the "const" test. If not, the "const" test will fail, since
         // we use wabt to parse the tests and wabt uses strtof.
@@ -176,5 +178,6 @@ fn ignore(testsuite: &str, name: &str) -> bool {
             };
         }
     }
+
     false
 }


### PR DESCRIPTION
This difference causes the spec test const.wast to fail, so disable the
test on platforms where we detect the rounding difference occurs.