### PR TITLE
[wasmtime-api] Implementation of classes for run-{reflect,start,global,memory}-c

### DIFF
--- a/wasmtime-api/src/externals.rs
+++ b/wasmtime-api/src/externals.rs
@@ -1,13 +1,13 @@
 use crate::callable::{Callable, WasmtimeFn};
 use crate::runtime::Store;
 use crate::trap::Trap;
-use crate::types::{ExternType, FuncType, GlobalType, MemoryType, TableType};
+use crate::types::{ExternType, FuncType, GlobalType, MemoryType, TableType, ValType};
 use crate::values::Val;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::result::Result;
 
-use crate::trampoline::generate_func_export;
+use crate::trampoline::{generate_func_export, generate_global_export, generate_memory_export};
 use wasmtime_runtime::InstanceHandle;
 // Externals
 
@@ -61,6 +61,8 @@ impl Extern {
                 }
                 f.borrow().anchor.as_ref().unwrap().1.clone()
             }
+            Extern::Global(g) => g.borrow().wasmtime_export().clone(),
+            Extern::Memory(m) => m.borrow().wasmtime_export().clone(),
             _ => unimplemented!("get_wasmtime_export"),
         }
     }
@@ -70,7 +72,6 @@ impl Extern {
         instance_handle: InstanceHandle,
         export: wasmtime_runtime::Export,
     ) -> Extern {
-        use cranelift_wasm::GlobalInit;
         match export {
             wasmtime_runtime::Export::Function {
                 address,
@@ -83,30 +84,12 @@ impl Extern {
                 f.anchor = Some((instance_handle, export.clone()));
                 Extern::Func(Rc::new(RefCell::new(f)))
             }
-            wasmtime_runtime::Export::Memory {
-                definition: _,
-                vmctx: _,
-                memory,
-            } => {
-                let ty = MemoryType::from_cranelift_memory(memory.memory.clone());
-                let m = Memory::new(store, ty);
-                Extern::Memory(Rc::new(RefCell::new(m)))
-            }
-            wasmtime_runtime::Export::Global {
-                definition: _,
-                vmctx: _,
-                global,
-            } => {
-                let ty = GlobalType::from_cranelift_global(global.clone());
-                let val = match global.initializer {
-                    GlobalInit::I32Const(i) => Val::from(i),
-                    GlobalInit::I64Const(i) => Val::from(i),
-                    GlobalInit::F32Const(f) => Val::from_f32_bits(f),
-                    GlobalInit::F64Const(f) => Val::from_f64_bits(f),
-                    _ => unimplemented!("from_wasmtime_export initializer"),
-                };
-                Extern::Global(Rc::new(RefCell::new(Global::new(store, ty, val))))
-            }
+            wasmtime_runtime::Export::Memory { .. } => Extern::Memory(Rc::new(RefCell::new(
+                Memory::from_wasmtime_memory(export, store, instance_handle),
+            ))),
+            wasmtime_runtime::Export::Global { .. } => Extern::Global(Rc::new(RefCell::new(
+                Global::from_wasmtime_global(export, store),
+            ))),
             wasmtime_runtime::Export::Table {
                 definition: _,
                 vmctx: _,
@@ -166,15 +149,20 @@ impl Func {
 pub struct Global {
     _store: Rc<RefCell<Store>>,
     r#type: GlobalType,
-    val: Val,
+    wasmtime_export: wasmtime_runtime::Export,
+    #[allow(dead_code)]
+    wasmtime_state: Option<crate::trampoline::GlobalState>,
 }
 
 impl Global {
     pub fn new(store: Rc<RefCell<Store>>, r#type: GlobalType, val: Val) -> Global {
+        let (wasmtime_export, wasmtime_state) =
+            generate_global_export(&r#type, val).expect("generated global");
         Global {
             _store: store,
             r#type,
-            val,
+            wasmtime_export,
+            wasmtime_state: Some(wasmtime_state),
         }
     }
 
@@ -182,12 +170,66 @@ impl Global {
         &self.r#type
     }
 
-    pub fn get(&self) -> &Val {
-        &self.val
+    fn wasmtime_global_definition(&self) -> *mut wasmtime_runtime::VMGlobalDefinition {
+        match self.wasmtime_export {
+            wasmtime_runtime::Export::Global { definition, .. } => definition,
+            _ => panic!("global definition not found"),
+        }
+    }
+
+    pub fn get(&self) -> Val {
+        let definition = unsafe { &mut *self.wasmtime_global_definition() };
+        unsafe {
+            match self.r#type().content() {
+                ValType::I32 => Val::from(*definition.as_i32()),
+                ValType::I64 => Val::from(*definition.as_i64()),
+                ValType::F32 => Val::from_f32_bits(*definition.as_u32()),
+                ValType::F64 => Val::from_f64_bits(*definition.as_u64()),
+                _ => unimplemented!("Global::get for {:?}", self.r#type().content()),
+            }
+        }
     }
 
     pub fn set(&mut self, val: Val) {
-        self.val = val;
+        if val.r#type() != *self.r#type().content() {
+            panic!(
+                "global of type {:?} cannot be set to {:?}",
+                self.r#type().content(),
+                val.r#type()
+            );
+        }
+        let definition = unsafe { &mut *self.wasmtime_global_definition() };
+        unsafe {
+            match val {
+                Val::I32(i) => *definition.as_i32_mut() = i,
+                Val::I64(i) => *definition.as_i64_mut() = i,
+                Val::F32(f) => *definition.as_u32_mut() = f,
+                Val::F64(f) => *definition.as_u64_mut() = f,
+                _ => unimplemented!("Global::set for {:?}", val.r#type()),
+            }
+        }
+    }
+
+    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
+        &self.wasmtime_export
+    }
+
+    pub(crate) fn from_wasmtime_global(
+        export: wasmtime_runtime::Export,
+        store: Rc<RefCell<Store>>,
+    ) -> Global {
+        let global = if let wasmtime_runtime::Export::Global { ref global, .. } = export {
+            global
+        } else {
+            panic!("wasmtime export is not memory")
+        };
+        let ty = GlobalType::from_cranelift_global(global.clone());
+        Global {
+            _store: store,
+            r#type: ty,
+            wasmtime_export: export,
+            wasmtime_state: None,
+        }
     }
 }
 
@@ -228,13 +270,19 @@ impl Table {
 pub struct Memory {
     _store: Rc<RefCell<Store>>,
     r#type: MemoryType,
+    wasmtime_handle: InstanceHandle,
+    wasmtime_export: wasmtime_runtime::Export,
 }
 
 impl Memory {
     pub fn new(store: Rc<RefCell<Store>>, r#type: MemoryType) -> Memory {
+        let (wasmtime_handle, wasmtime_export) =
+            generate_memory_export(&r#type).expect("generated memory");
         Memory {
             _store: store,
             r#type,
+            wasmtime_handle,
+            wasmtime_export,
         }
     }
 
@@ -242,19 +290,56 @@ impl Memory {
         &self.r#type
     }
 
-    pub fn data(&self) -> *const u8 {
-        unimplemented!("Memory::data")
+    fn wasmtime_memory_definition(&self) -> *mut wasmtime_runtime::VMMemoryDefinition {
+        match self.wasmtime_export {
+            wasmtime_runtime::Export::Memory { definition, .. } => definition,
+            _ => panic!("memory definition not found"),
+        }
+    }
+
+    pub fn data(&self) -> *mut u8 {
+        unsafe { (*self.wasmtime_memory_definition()).base }
     }
 
     pub fn data_size(&self) -> usize {
-        unimplemented!("Memory::data_size")
+        unsafe { (*self.wasmtime_memory_definition()).current_length }
     }
 
     pub fn size(&self) -> u32 {
-        unimplemented!("Memory::size")
+        (self.data_size() / wasmtime_environ::WASM_PAGE_SIZE as usize) as u32
     }
 
-    pub fn grow(&mut self, _delta: u32) -> bool {
-        unimplemented!("Memory::grow")
+    pub fn grow(&mut self, delta: u32) -> bool {
+        match self.wasmtime_export {
+            wasmtime_runtime::Export::Memory { definition, .. } => {
+                let definition = unsafe { &(*definition) };
+                let index = self.wasmtime_handle.memory_index(definition);
+                self.wasmtime_handle.memory_grow(index, delta).is_some()
+            }
+            _ => panic!("memory definition not found"),
+        }
+    }
+
+    pub(crate) fn wasmtime_export(&self) -> &wasmtime_runtime::Export {
+        &self.wasmtime_export
+    }
+
+    pub(crate) fn from_wasmtime_memory(
+        export: wasmtime_runtime::Export,
+        store: Rc<RefCell<Store>>,
+        instance_handle: wasmtime_runtime::InstanceHandle,
+    ) -> Memory {
+        let memory = if let wasmtime_runtime::Export::Memory { ref memory, .. } = export {
+            memory
+        } else {
+            panic!("wasmtime export is not memory")
+        };
+        let ty = MemoryType::from_cranelift_memory(memory.memory.clone());
+        Memory {
+            _store: store,
+            r#type: ty,
+            wasmtime_handle: instance_handle,
+            wasmtime_export: export,
+        }
     }
 }

--- a/wasmtime-api/src/trampoline/create_handle.rs
+++ b/wasmtime-api/src/trampoline/create_handle.rs
@@ -1,247 +1,34 @@
 //! Support for a calling of an imported function.
 
-use crate::trampoline::code_memory::CodeMemory;
-use cranelift_codegen::ir::types;
-use cranelift_codegen::ir::{InstBuilder, StackSlotData, StackSlotKind, TrapCode};
-use cranelift_codegen::Context;
-use cranelift_codegen::{binemit, ir, isa};
-use cranelift_entity::{EntityRef, PrimaryMap};
-use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-use cranelift_wasm::{DefinedFuncIndex, FuncIndex};
+use cranelift_entity::PrimaryMap;
+use cranelift_wasm::DefinedFuncIndex;
 //use target_lexicon::HOST;
 use failure::Error;
-use wasmtime_environ::{Export, Module};
-use wasmtime_runtime::{Imports, InstanceHandle, VMContext, VMFunctionBody};
+use wasmtime_environ::Module;
+use wasmtime_runtime::{Imports, InstanceHandle, VMFunctionBody};
 
-use core::cmp;
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use crate::{Func, Trap, Val};
-
-struct TrampolineState {
-    func: Rc<RefCell<Func>>,
-    trap: Option<Rc<RefCell<Trap>>>,
-    #[allow(dead_code)]
-    code_memory: CodeMemory,
-}
-
-unsafe extern "C" fn stub_fn(vmctx: *mut VMContext, call_id: u32, values_vec: *mut i64) -> u32 {
-    let mut instance = InstanceHandle::from_vmctx(vmctx);
-
-    let (args, returns_len) = {
-        let module = instance.module_ref();
-        let signature = &module.signatures[module.functions[FuncIndex::new(call_id as usize)]];
-
-        let mut args = Vec::new();
-        for i in 1..signature.params.len() {
-            args.push(Val::read_value_from(
-                values_vec.offset(i as isize - 1),
-                signature.params[i].value_type,
-            ))
-        }
-        (args, signature.returns.len())
-    };
-
-    let func = instance
-        .host_state()
-        .downcast_mut::<TrampolineState>()
-        .expect("state")
-        .func
-        .borrow();
-
-    match func.call(&args) {
-        Ok(returns) => {
-            for i in 0..returns_len {
-                // TODO check signature.returns[i].value_type ?
-                returns[i].write_value_to(values_vec.offset(i as isize));
-            }
-            0
-        }
-        Err(trap) => {
-            // TODO read custom exception
-            InstanceHandle::from_vmctx(vmctx)
-                .host_state()
-                .downcast_mut::<TrampolineState>()
-                .expect("state")
-                .trap = Some(trap);
-            1
-        }
-    }
-}
-
-/// Create a trampoline for invoking a Callable.
-fn make_trampoline(
-    isa: &dyn isa::TargetIsa,
-    code_memory: &mut CodeMemory,
-    fn_builder_ctx: &mut FunctionBuilderContext,
-    call_id: u32,
-    signature: &ir::Signature,
-) -> *const VMFunctionBody {
-    // Mostly reverse copy of the similar method from wasmtime's
-    // wasmtime-jit/src/compiler.rs.
-    let pointer_type = isa.pointer_type();
-    let mut stub_sig = ir::Signature::new(isa.frontend_config().default_call_conv);
-
-    // Add the `vmctx` parameter.
-    stub_sig.params.push(ir::AbiParam::special(
-        pointer_type,
-        ir::ArgumentPurpose::VMContext,
-    ));
-
-    // Add the `call_id` parameter.
-    stub_sig.params.push(ir::AbiParam::new(types::I32));
-
-    // Add the `values_vec` parameter.
-    stub_sig.params.push(ir::AbiParam::new(pointer_type));
-
-    // Add error/trap return.
-    stub_sig.returns.push(ir::AbiParam::new(types::I32));
-
-    let values_vec_len = 8 * cmp::max(signature.params.len() - 1, signature.returns.len()) as u32;
-
-    let mut context = Context::new();
-    context.func =
-        ir::Function::with_name_signature(ir::ExternalName::user(0, 0), signature.clone());
-
-    let ss = context.func.create_stack_slot(StackSlotData::new(
-        StackSlotKind::ExplicitSlot,
-        values_vec_len,
-    ));
-    let value_size = 8;
-
-    {
-        let mut builder = FunctionBuilder::new(&mut context.func, fn_builder_ctx);
-        let block0 = builder.create_ebb();
-
-        builder.append_ebb_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
-
-        let values_vec_ptr_val = builder.ins().stack_addr(pointer_type, ss, 0);
-        let mflags = ir::MemFlags::trusted();
-        for i in 1..signature.params.len() {
-            if i == 0 {
-                continue;
-            }
-
-            let val = builder.func.dfg.ebb_params(block0)[i];
-            builder.ins().store(
-                mflags,
-                val,
-                values_vec_ptr_val,
-                ((i - 1) * value_size) as i32,
-            );
-        }
-
-        let vmctx_ptr_val = builder.func.dfg.ebb_params(block0)[0];
-        let call_id_val = builder.ins().iconst(types::I32, call_id as i64);
-
-        let callee_args = vec![vmctx_ptr_val, call_id_val, values_vec_ptr_val];
-
-        let new_sig = builder.import_signature(stub_sig.clone());
-
-        let callee_value = builder
-            .ins()
-            .iconst(pointer_type, stub_fn as *const VMFunctionBody as i64);
-        let call = builder
-            .ins()
-            .call_indirect(new_sig, callee_value, &callee_args);
-
-        let call_result = builder.func.dfg.inst_results(call)[0];
-        builder.ins().trapnz(call_result, TrapCode::User(0));
-
-        let mflags = ir::MemFlags::trusted();
-        let mut results = Vec::new();
-        for (i, r) in signature.returns.iter().enumerate() {
-            let load = builder.ins().load(
-                r.value_type,
-                mflags,
-                values_vec_ptr_val,
-                (i * value_size) as i32,
-            );
-            results.push(load);
-        }
-        builder.ins().return_(&results);
-        builder.finalize()
-    }
-
-    let mut code_buf: Vec<u8> = Vec::new();
-    let mut reloc_sink = RelocSink {};
-    let mut trap_sink = binemit::NullTrapSink {};
-    let mut stackmap_sink = binemit::NullStackmapSink {};
-    context
-        .compile_and_emit(
-            isa,
-            &mut code_buf,
-            &mut reloc_sink,
-            &mut trap_sink,
-            &mut stackmap_sink,
-        )
-        .expect("compile_and_emit");
-
-    code_memory
-        .allocate_copy_of_byte_slice(&code_buf)
-        .expect("allocate_copy_of_byte_slice")
-        .as_ptr()
-}
-
-pub fn create_handle(func: &Rc<RefCell<Func>>) -> Result<InstanceHandle, Error> {
-    let sig = func.borrow().r#type().get_cranelift_signature().clone();
-
-    let isa = {
-        let isa_builder =
-            cranelift_native::builder().expect("host machine is not a supported target");
-        let flag_builder = cranelift_codegen::settings::builder();
-        isa_builder.finish(cranelift_codegen::settings::Flags::new(flag_builder))
-    };
-
+pub fn create_handle(
+    module: Module,
+    finished_functions: PrimaryMap<DefinedFuncIndex, *const VMFunctionBody>,
+    state: Box<dyn Any>,
+) -> Result<InstanceHandle, Error> {
     let global_exports: Rc<RefCell<HashMap<String, Option<wasmtime_runtime::Export>>>> =
         Rc::new(RefCell::new(HashMap::new()));
-    let mut fn_builder_ctx = FunctionBuilderContext::new();
-    let mut module = Module::new();
-    let mut finished_functions: PrimaryMap<DefinedFuncIndex, *const VMFunctionBody> =
-        PrimaryMap::new();
-    let mut code_memory = CodeMemory::new();
-
-    //let pointer_type = types::Type::triple_pointer_type(&HOST);
-    //let call_conv = isa::CallConv::triple_default(&HOST);
-
-    let dependencies = HashSet::new();
-    let memories = PrimaryMap::new();
-
-    let sig_id = module.signatures.push(sig.clone());
-    let func_id = module.functions.push(sig_id);
-    module
-        .exports
-        .insert("trampoline".to_string(), Export::Function(func_id));
-    let trampoline = make_trampoline(
-        isa.as_ref(),
-        &mut code_memory,
-        &mut fn_builder_ctx,
-        func_id.index() as u32,
-        &sig,
-    );
-    code_memory.publish();
-
-    finished_functions.push(trampoline);
 
     let imports = Imports::new(
-        dependencies,
+        HashSet::new(),
         PrimaryMap::new(),
         PrimaryMap::new(),
-        memories,
+        PrimaryMap::new(),
         PrimaryMap::new(),
     );
     let data_initializers = Vec::new();
     let signatures = PrimaryMap::new();
-
-    let trampoline_state = TrampolineState {
-        func: func.clone(),
-        trap: None,
-        code_memory,
-    };
 
     Ok(InstanceHandle::new(
         Rc::new(module),
@@ -251,39 +38,7 @@ pub fn create_handle(func: &Rc<RefCell<Func>>) -> Result<InstanceHandle, Error> 
         &data_initializers,
         signatures.into_boxed_slice(),
         None,
-        Box::new(trampoline_state),
+        state,
     )
     .expect("instance"))
-}
-
-/// We don't expect trampoline compilation to produce any relocations, so
-/// this `RelocSink` just asserts that it doesn't recieve any.
-struct RelocSink {}
-
-impl binemit::RelocSink for RelocSink {
-    fn reloc_ebb(
-        &mut self,
-        _offset: binemit::CodeOffset,
-        _reloc: binemit::Reloc,
-        _ebb_offset: binemit::CodeOffset,
-    ) {
-        panic!("trampoline compilation should not produce ebb relocs");
-    }
-    fn reloc_external(
-        &mut self,
-        _offset: binemit::CodeOffset,
-        _reloc: binemit::Reloc,
-        _name: &ir::ExternalName,
-        _addend: binemit::Addend,
-    ) {
-        panic!("trampoline compilation should not produce external symbol relocs");
-    }
-    fn reloc_jt(
-        &mut self,
-        _offset: binemit::CodeOffset,
-        _reloc: binemit::Reloc,
-        _jt: ir::JumpTable,
-    ) {
-        panic!("trampoline compilation should not produce jump table relocs");
-    }
 }

--- a/wasmtime-api/src/trampoline/func.rs
+++ b/wasmtime-api/src/trampoline/func.rs
@@ -1,0 +1,265 @@
+//! Support for a calling of an imported function.
+
+use crate::trampoline::code_memory::CodeMemory;
+use cranelift_codegen::ir::types;
+use cranelift_codegen::ir::{InstBuilder, StackSlotData, StackSlotKind, TrapCode};
+use cranelift_codegen::Context;
+use cranelift_codegen::{binemit, ir, isa};
+use cranelift_entity::{EntityRef, PrimaryMap};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_wasm::{DefinedFuncIndex, FuncIndex};
+//use target_lexicon::HOST;
+use failure::Error;
+use wasmtime_environ::{Export, Module};
+use wasmtime_runtime::{InstanceHandle, VMContext, VMFunctionBody};
+
+use core::cmp;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::{Func, Trap, Val};
+
+use super::create_handle::create_handle;
+
+struct TrampolineState {
+    func: Rc<RefCell<Func>>,
+    trap: Option<Rc<RefCell<Trap>>>,
+    #[allow(dead_code)]
+    code_memory: CodeMemory,
+}
+
+unsafe extern "C" fn stub_fn(vmctx: *mut VMContext, call_id: u32, values_vec: *mut i64) -> u32 {
+    let mut instance = InstanceHandle::from_vmctx(vmctx);
+
+    let (args, returns_len) = {
+        let module = instance.module_ref();
+        let signature = &module.signatures[module.functions[FuncIndex::new(call_id as usize)]];
+
+        let mut args = Vec::new();
+        for i in 1..signature.params.len() {
+            args.push(Val::read_value_from(
+                values_vec.offset(i as isize - 1),
+                signature.params[i].value_type,
+            ))
+        }
+        (args, signature.returns.len())
+    };
+
+    let func = instance
+        .host_state()
+        .downcast_mut::<TrampolineState>()
+        .expect("state")
+        .func
+        .borrow();
+
+    match func.call(&args) {
+        Ok(returns) => {
+            for i in 0..returns_len {
+                // TODO check signature.returns[i].value_type ?
+                returns[i].write_value_to(values_vec.offset(i as isize));
+            }
+            0
+        }
+        Err(trap) => {
+            // TODO read custom exception
+            InstanceHandle::from_vmctx(vmctx)
+                .host_state()
+                .downcast_mut::<TrampolineState>()
+                .expect("state")
+                .trap = Some(trap);
+            1
+        }
+    }
+}
+
+/// Create a trampoline for invoking a Callable.
+fn make_trampoline(
+    isa: &dyn isa::TargetIsa,
+    code_memory: &mut CodeMemory,
+    fn_builder_ctx: &mut FunctionBuilderContext,
+    call_id: u32,
+    signature: &ir::Signature,
+) -> *const VMFunctionBody {
+    // Mostly reverse copy of the similar method from wasmtime's
+    // wasmtime-jit/src/compiler.rs.
+    let pointer_type = isa.pointer_type();
+    let mut stub_sig = ir::Signature::new(isa.frontend_config().default_call_conv);
+
+    // Add the `vmctx` parameter.
+    stub_sig.params.push(ir::AbiParam::special(
+        pointer_type,
+        ir::ArgumentPurpose::VMContext,
+    ));
+
+    // Add the `call_id` parameter.
+    stub_sig.params.push(ir::AbiParam::new(types::I32));
+
+    // Add the `values_vec` parameter.
+    stub_sig.params.push(ir::AbiParam::new(pointer_type));
+
+    // Add error/trap return.
+    stub_sig.returns.push(ir::AbiParam::new(types::I32));
+
+    let values_vec_len = 8 * cmp::max(signature.params.len() - 1, signature.returns.len()) as u32;
+
+    let mut context = Context::new();
+    context.func =
+        ir::Function::with_name_signature(ir::ExternalName::user(0, 0), signature.clone());
+
+    let ss = context.func.create_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        values_vec_len,
+    ));
+    let value_size = 8;
+
+    {
+        let mut builder = FunctionBuilder::new(&mut context.func, fn_builder_ctx);
+        let block0 = builder.create_ebb();
+
+        builder.append_ebb_params_for_function_params(block0);
+        builder.switch_to_block(block0);
+        builder.seal_block(block0);
+
+        let values_vec_ptr_val = builder.ins().stack_addr(pointer_type, ss, 0);
+        let mflags = ir::MemFlags::trusted();
+        for i in 1..signature.params.len() {
+            if i == 0 {
+                continue;
+            }
+
+            let val = builder.func.dfg.ebb_params(block0)[i];
+            builder.ins().store(
+                mflags,
+                val,
+                values_vec_ptr_val,
+                ((i - 1) * value_size) as i32,
+            );
+        }
+
+        let vmctx_ptr_val = builder.func.dfg.ebb_params(block0)[0];
+        let call_id_val = builder.ins().iconst(types::I32, call_id as i64);
+
+        let callee_args = vec![vmctx_ptr_val, call_id_val, values_vec_ptr_val];
+
+        let new_sig = builder.import_signature(stub_sig.clone());
+
+        let callee_value = builder
+            .ins()
+            .iconst(pointer_type, stub_fn as *const VMFunctionBody as i64);
+        let call = builder
+            .ins()
+            .call_indirect(new_sig, callee_value, &callee_args);
+
+        let call_result = builder.func.dfg.inst_results(call)[0];
+        builder.ins().trapnz(call_result, TrapCode::User(0));
+
+        let mflags = ir::MemFlags::trusted();
+        let mut results = Vec::new();
+        for (i, r) in signature.returns.iter().enumerate() {
+            let load = builder.ins().load(
+                r.value_type,
+                mflags,
+                values_vec_ptr_val,
+                (i * value_size) as i32,
+            );
+            results.push(load);
+        }
+        builder.ins().return_(&results);
+        builder.finalize()
+    }
+
+    let mut code_buf: Vec<u8> = Vec::new();
+    let mut reloc_sink = RelocSink {};
+    let mut trap_sink = binemit::NullTrapSink {};
+    let mut stackmap_sink = binemit::NullStackmapSink {};
+    context
+        .compile_and_emit(
+            isa,
+            &mut code_buf,
+            &mut reloc_sink,
+            &mut trap_sink,
+            &mut stackmap_sink,
+        )
+        .expect("compile_and_emit");
+
+    code_memory
+        .allocate_copy_of_byte_slice(&code_buf)
+        .expect("allocate_copy_of_byte_slice")
+        .as_ptr()
+}
+
+pub fn create_handle_with_function(func: &Rc<RefCell<Func>>) -> Result<InstanceHandle, Error> {
+    let sig = func.borrow().r#type().get_cranelift_signature().clone();
+
+    let isa = {
+        let isa_builder =
+            cranelift_native::builder().expect("host machine is not a supported target");
+        let flag_builder = cranelift_codegen::settings::builder();
+        isa_builder.finish(cranelift_codegen::settings::Flags::new(flag_builder))
+    };
+
+    let mut fn_builder_ctx = FunctionBuilderContext::new();
+    let mut module = Module::new();
+    let mut finished_functions: PrimaryMap<DefinedFuncIndex, *const VMFunctionBody> =
+        PrimaryMap::new();
+    let mut code_memory = CodeMemory::new();
+
+    //let pointer_type = types::Type::triple_pointer_type(&HOST);
+    //let call_conv = isa::CallConv::triple_default(&HOST);
+
+    let sig_id = module.signatures.push(sig.clone());
+    let func_id = module.functions.push(sig_id);
+    module
+        .exports
+        .insert("trampoline".to_string(), Export::Function(func_id));
+    let trampoline = make_trampoline(
+        isa.as_ref(),
+        &mut code_memory,
+        &mut fn_builder_ctx,
+        func_id.index() as u32,
+        &sig,
+    );
+    code_memory.publish();
+
+    finished_functions.push(trampoline);
+
+    let trampoline_state = TrampolineState {
+        func: func.clone(),
+        trap: None,
+        code_memory,
+    };
+
+    create_handle(module, finished_functions, Box::new(trampoline_state))
+}
+
+/// We don't expect trampoline compilation to produce any relocations, so
+/// this `RelocSink` just asserts that it doesn't recieve any.
+struct RelocSink {}
+
+impl binemit::RelocSink for RelocSink {
+    fn reloc_ebb(
+        &mut self,
+        _offset: binemit::CodeOffset,
+        _reloc: binemit::Reloc,
+        _ebb_offset: binemit::CodeOffset,
+    ) {
+        panic!("trampoline compilation should not produce ebb relocs");
+    }
+    fn reloc_external(
+        &mut self,
+        _offset: binemit::CodeOffset,
+        _reloc: binemit::Reloc,
+        _name: &ir::ExternalName,
+        _addend: binemit::Addend,
+    ) {
+        panic!("trampoline compilation should not produce external symbol relocs");
+    }
+    fn reloc_jt(
+        &mut self,
+        _offset: binemit::CodeOffset,
+        _reloc: binemit::Reloc,
+        _jt: ir::JumpTable,
+    ) {
+        panic!("trampoline compilation should not produce jump table relocs");
+    }
+}

--- a/wasmtime-api/src/trampoline/global.rs
+++ b/wasmtime-api/src/trampoline/global.rs
@@ -1,0 +1,47 @@
+use cranelift_entity::PrimaryMap;
+use failure::Error;
+use wasmtime_environ::Module;
+use wasmtime_runtime::{InstanceHandle, VMGlobalDefinition};
+
+use super::create_handle::create_handle;
+use crate::{GlobalType, Mutability, Val};
+
+#[allow(dead_code)]
+pub struct GlobalState {
+    definition: Box<VMGlobalDefinition>,
+    handle: InstanceHandle,
+}
+
+pub fn create_global(
+    gt: &GlobalType,
+    val: Val,
+) -> Result<(wasmtime_runtime::Export, GlobalState), Error> {
+    let mut definition = Box::new(VMGlobalDefinition::new());
+    unsafe {
+        match val {
+            Val::I32(i) => *definition.as_i32_mut() = i,
+            Val::I64(i) => *definition.as_i64_mut() = i,
+            Val::F32(f) => *definition.as_u32_mut() = f,
+            Val::F64(f) => *definition.as_u64_mut() = f,
+            _ => unimplemented!("create_global for {:?}", gt),
+        }
+    }
+
+    let global = cranelift_wasm::Global {
+        ty: gt.content().get_cranelift_type(),
+        mutability: match gt.mutability() {
+            Mutability::Const => false,
+            Mutability::Var => true,
+        },
+        initializer: cranelift_wasm::GlobalInit::Import, // TODO is it right?
+    };
+    let mut handle = create_handle(Module::new(), PrimaryMap::new(), Box::new(())).expect("handle");
+    Ok((
+        wasmtime_runtime::Export::Global {
+            definition: definition.as_mut(),
+            vmctx: handle.vmctx_mut_ptr(),
+            global,
+        },
+        GlobalState { definition, handle },
+    ))
+}

--- a/wasmtime-api/src/trampoline/memory.rs
+++ b/wasmtime-api/src/trampoline/memory.rs
@@ -1,0 +1,33 @@
+use cranelift_entity::PrimaryMap;
+use failure::Error;
+use wasmtime_environ::Module;
+use wasmtime_runtime::InstanceHandle;
+
+use super::create_handle::create_handle;
+use crate::MemoryType;
+
+#[allow(dead_code)]
+
+pub fn create_handle_with_memory(memory: &MemoryType) -> Result<InstanceHandle, Error> {
+    let mut module = Module::new();
+
+    let memory = cranelift_wasm::Memory {
+        minimum: memory.limits().min(),
+        maximum: if memory.limits().max() == std::u32::MAX {
+            None
+        } else {
+            Some(memory.limits().max())
+        },
+        shared: false, // TODO
+    };
+    let tunable = Default::default();
+
+    let memory_plan = wasmtime_environ::MemoryPlan::for_memory(memory, &tunable);
+    let memory_id = module.memory_plans.push(memory_plan);
+    module.exports.insert(
+        "memory".to_string(),
+        wasmtime_environ::Export::Memory(memory_id),
+    );
+
+    create_handle(module, PrimaryMap::new(), Box::new(()))
+}

--- a/wasmtime-api/src/trampoline/mod.rs
+++ b/wasmtime-api/src/trampoline/mod.rs
@@ -2,18 +2,40 @@
 
 mod code_memory;
 mod create_handle;
+mod func;
+mod global;
+mod memory;
 
 use failure::Error;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use self::create_handle::create_handle;
-use super::externals::Func;
+use self::func::create_handle_with_function;
+use self::global::create_global;
+use self::memory::create_handle_with_memory;
+use super::{Func, GlobalType, MemoryType, Val};
+
+pub use self::global::GlobalState;
 
 pub fn generate_func_export(f: &Rc<RefCell<Func>>) -> Result<(), Error> {
-    let mut instance = create_handle(f)?;
+    let mut instance = create_handle_with_function(f)?;
     let export = instance.lookup("trampoline").expect("trampoline export");
 
     f.borrow_mut().anchor = Some((instance, export));
     Ok(())
+}
+
+pub fn generate_global_export(
+    gt: &GlobalType,
+    val: Val,
+) -> Result<(wasmtime_runtime::Export, GlobalState), Error> {
+    create_global(gt, val)
+}
+
+pub fn generate_memory_export(
+    m: &MemoryType,
+) -> Result<(wasmtime_runtime::InstanceHandle, wasmtime_runtime::Export), Error> {
+    let mut instance = create_handle_with_memory(m)?;
+    let export = instance.lookup("memory").expect("memory export");
+    Ok((instance, export))
 }

--- a/wasmtime-api/src/types.rs
+++ b/wasmtime-api/src/types.rs
@@ -39,7 +39,7 @@ impl Limits {
 
 // Value Types
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ValType {
     I32,
     I64,

--- a/wasmtime-api/src/types.rs
+++ b/wasmtime-api/src/types.rs
@@ -27,6 +27,14 @@ impl Limits {
             max: ::std::u32::MAX,
         }
     }
+
+    pub fn min(&self) -> u32 {
+        self.min
+    }
+
+    pub fn max(&self) -> u32 {
+        self.max
+    }
 }
 
 // Value Types
@@ -236,6 +244,17 @@ impl TableType {
     }
     pub fn limits(&self) -> &Limits {
         &self.limits
+    }
+
+    pub(crate) fn from_cranelift_table(table: cranelift_wasm::Table) -> TableType {
+        assert!(if let cranelift_wasm::TableElementType::Func = table.ty {
+            true
+        } else {
+            false
+        });
+        let ty = ValType::FuncRef;
+        let limits = Limits::new(table.minimum, table.maximum.unwrap_or(::std::u32::MAX));
+        TableType::new(ty, limits)
     }
 }
 


### PR DESCRIPTION
Fix several critical wasm-c-api examples:
- reflect.c
- start.c
- global.c
- memory.c
