### PR TITLE
Use `winapi::ctypes::c_void` on Windows.

### DIFF
--- a/wasmtime-runtime/src/mmap.rs
+++ b/wasmtime-runtime/src/mmap.rs
@@ -187,7 +187,7 @@ impl Mmap {
     /// `self`'s reserved memory.
     #[cfg(target_os = "windows")]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
-        use core::ffi::c_void;
+        use winapi::ctypes::c_void;
         use winapi::um::memoryapi::VirtualAlloc;
         use winapi::um::winnt::{MEM_COMMIT, PAGE_READWRITE};
         let page_size = region::page::size();
@@ -251,9 +251,10 @@ impl Drop for Mmap {
     #[cfg(target_os = "windows")]
     fn drop(&mut self) {
         if self.len != 0 {
+            use winapi::ctypes::c_void;
             use winapi::um::memoryapi::VirtualFree;
             use winapi::um::winnt::MEM_RELEASE;
-            let r = unsafe { VirtualFree(self.ptr as *mut libc::c_void, self.len, MEM_RELEASE) };
+            let r = unsafe { VirtualFree(self.ptr as *mut c_void, self.len, MEM_RELEASE) };
             assert_eq!(r, 0);
         }
     }


### PR DESCRIPTION
`winapi::ctypes::c_void` is apparently distinct from `core::ffi::c_void`
and `libc::c_void`.