### PR TITLE
Refactor wasmtime-wasi crate

### DIFF
--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -7,6 +7,7 @@ categories = ["wasm"]
 repository = "https://github.com/CraneStation/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 wasmtime-runtime = { path = "../wasmtime-runtime" }

--- a/wasmtime-wasi/src/instantiate.rs
+++ b/wasmtime-wasi/src/instantiate.rs
@@ -1,3 +1,4 @@
+use super::syscalls;
 use cranelift_codegen::ir::types;
 use cranelift_codegen::{ir, isa};
 use cranelift_entity::PrimaryMap;
@@ -6,7 +7,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
 use std::rc::Rc;
-use syscalls;
 use target_lexicon::HOST;
 use wasi_common::WasiCtxBuilder;
 use wasmtime_environ::{translate_signature, Export, Module};

--- a/wasmtime-wasi/src/lib.rs
+++ b/wasmtime-wasi/src/lib.rs
@@ -1,14 +1,3 @@
-extern crate cranelift_codegen;
-extern crate cranelift_entity;
-extern crate cranelift_wasm;
-extern crate target_lexicon;
-extern crate wasmtime_environ;
-extern crate wasmtime_jit;
-extern crate wasmtime_runtime;
-#[macro_use]
-extern crate log;
-extern crate wasi_common;
-
 mod instantiate;
 mod syscalls;
 


### PR DESCRIPTION
Changes:
* uses Rust edition 2018
* returns wasm32 errno directly rather than relying on
  wasi_common::{host, memory} modules
* wraps extraction of memory and WASI context in a macro