### PR TITLE
Run initial SIMD spec tests 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ failure = "0.1"
 target-lexicon = { version = "0.8.1", default-features = false }
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.1"
-wabt = "0.9"
+wabt = "0.9.2"
 libc = "0.2.60"
 errno = "0.2.4"
 rayon = "1.1"

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@
 //! to automatically run the files in parallel.
 
 use std::env;
-use std::fs::{read_dir, DirEntry, File};
+use std::fs::{read_dir, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -16,6 +16,7 @@ fn main() {
 
     test_directory(&mut out, "misc_testsuite").expect("generating tests");
     test_directory(&mut out, "spec_testsuite").expect("generating tests");
+    test_file(&mut out, "spec_testsuite/proposals/simd/simd_const.wast").expect("generating tests");
 }
 
 fn test_directory(out: &mut File, testsuite: &str) -> io::Result<()> {
@@ -58,14 +59,18 @@ fn test_directory(out: &mut File, testsuite: &str) -> io::Result<()> {
         "    use super::{{native_isa, Path, WastContext, Compiler, Features}};"
     )?;
     for dir_entry in dir_entries {
-        write_testsuite_tests(out, dir_entry, testsuite)?;
+        write_testsuite_tests(out, &dir_entry.path(), testsuite)?;
     }
     writeln!(out, "}}")?;
     Ok(())
 }
 
-fn write_testsuite_tests(out: &mut File, dir_entry: DirEntry, testsuite: &str) -> io::Result<()> {
-    let path = dir_entry.path();
+fn test_file(out: &mut File, testfile: &str) -> io::Result<()> {
+    let path = Path::new(testfile);
+    write_testsuite_tests(out, path, "single_file_spec_test")
+}
+
+fn write_testsuite_tests(out: &mut File, path: &Path, testsuite: &str) -> io::Result<()> {
     let stemstr = path
         .file_stem()
         .expect("file_stem")

--- a/build.rs
+++ b/build.rs
@@ -55,7 +55,7 @@ fn test_directory(out: &mut File, testsuite: &str) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "    use super::{{native_isa, Path, WastContext, Compiler}};"
+        "    use super::{{native_isa, Path, WastContext, Compiler, Features}};"
     )?;
     for dir_entry in dir_entries {
         write_testsuite_tests(out, dir_entry, testsuite)?;
@@ -85,7 +85,11 @@ fn write_testsuite_tests(out: &mut File, dir_entry: DirEntry, testsuite: &str) -
     writeln!(out, "        let compiler = Compiler::new(isa);")?;
     writeln!(
         out,
-        "        let mut wast_context = WastContext::new(Box::new(compiler));"
+        "        let features = Features {{ simd: true, ..Default::default() }};"
+    )?;
+    writeln!(
+        out,
+        "        let mut wast_context = WastContext::new(Box::new(compiler)).with_features(features);"
     )?;
     writeln!(out, "        wast_context")?;
     writeln!(out, "            .register_spectest()")?;

--- a/build.rs
+++ b/build.rs
@@ -183,6 +183,7 @@ fn ignore(testsuite: &str, name: &str) -> bool {
         {
             return match (testsuite, name) {
                 ("spec_testsuite", "const") => true,
+                ("single_file_spec_test", "simd_const") => true,
                 (_, _) => false,
             };
         }

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -4,7 +4,7 @@ use cranelift_codegen::isa;
 use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
 use std::path::Path;
-use wasmtime_jit::Compiler;
+use wasmtime_jit::{Compiler, Features};
 use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
@@ -14,6 +14,7 @@ fn native_isa() -> Box<dyn isa::TargetIsa> {
     let mut flag_builder = settings::builder();
     flag_builder.enable("enable_verifier").unwrap();
     flag_builder.enable("avoid_div_traps").unwrap();
+    flag_builder.enable("enable_simd").unwrap();
 
     let isa_builder = cranelift_native::builder().unwrap_or_else(|_| {
         panic!("host machine is not a supported target");

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -36,7 +36,7 @@ wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "8ea7
 docopt = "1.0.1"
 serde = { "version" = "1.0.94", features = ["derive"] }
 pretty_env_logger = "0.3.0"
-wabt = "0.9.0"
+wabt = "0.9.2"
 wasmtime-wast = { path="../wasmtime-wast" }
 wasmtime-wasi = { path="../wasmtime-wasi" }
 rayon = "1.1"

--- a/wasmtime-api/src/module.rs
+++ b/wasmtime-api/src/module.rs
@@ -32,6 +32,7 @@ fn into_valtype(ty: &wasmparser::Type) -> ValType {
         I64 => ValType::I64,
         F32 => ValType::F32,
         F64 => ValType::F64,
+        V128 => ValType::V128,
         AnyFunc => ValType::FuncRef,
         AnyRef => ValType::AnyRef,
         _ => unimplemented!("types in into_valtype"),

--- a/wasmtime-api/src/types.rs
+++ b/wasmtime-api/src/types.rs
@@ -45,6 +45,7 @@ pub enum ValType {
     I64,
     F32,
     F64,
+    V128,
     AnyRef, /* = 128 */
     FuncRef,
 }
@@ -70,6 +71,7 @@ impl ValType {
             ValType::I64 => ir::types::I64,
             ValType::F32 => ir::types::F32,
             ValType::F64 => ir::types::F64,
+            ValType::V128 => ir::types::I8X16,
             _ => unimplemented!("get_cranelift_type other"),
         }
     }
@@ -80,6 +82,7 @@ impl ValType {
             ir::types::I64 => ValType::I64,
             ir::types::F32 => ValType::F32,
             ir::types::F64 => ValType::F64,
+            ir::types::I8X16 => ValType::V128,
             _ => unimplemented!("from_cranelift_type other"),
         }
     }

--- a/wasmtime-api/src/wasm.rs
+++ b/wasmtime-api/src/wasm.rs
@@ -815,6 +815,7 @@ fn from_valtype(ty: &ValType) -> wasm_valkind_t {
         ValType::F64 => 3,
         ValType::AnyRef => 128,
         ValType::FuncRef => 129,
+        _ => panic!("wasm_valkind_t has no known conversion for {:?}", ty),
     }
 }
 

--- a/wasmtime-jit/src/action.rs
+++ b/wasmtime-jit/src/action.rs
@@ -7,7 +7,7 @@ use core::{fmt, mem, ptr, slice};
 use cranelift_codegen::ir;
 use std::string::String;
 use std::vec::Vec;
-use wasmtime_runtime::{wasmtime_call_trampoline, Export, InstanceHandle};
+use wasmtime_runtime::{wasmtime_call_trampoline, Export, InstanceHandle, VMInvokeArgument};
 
 /// A runtime value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -161,12 +161,12 @@ pub fn invoke(
         assert_eq!(value.value_type(), signature.params[index + 1].value_type);
     }
 
-    // TODO: Support values larger than u64. And pack the values into memory
+    // TODO: Support values larger than v128. And pack the values into memory
     // instead of just using fixed-sized slots.
     // Subtract one becase we don't pass the vmctx argument in `values_vec`.
-    let value_size = mem::size_of::<u64>();
-    let mut values_vec: Vec<u64> =
-        vec![0; max(signature.params.len() - 1, signature.returns.len())];
+    let value_size = mem::size_of::<VMInvokeArgument>();
+    let mut values_vec: Vec<VMInvokeArgument> =
+        vec![VMInvokeArgument::new(); max(signature.params.len() - 1, signature.returns.len())];
 
     // Store the argument values into `values_vec`.
     for (index, arg) in args.iter().enumerate() {

--- a/wasmtime-jit/src/action.rs
+++ b/wasmtime-jit/src/action.rs
@@ -20,6 +20,8 @@ pub enum RuntimeValue {
     F32(u32),
     /// A runtime value with type f64.
     F64(u64),
+    /// A runtime value with type v128
+    V128([u8; 16]),
 }
 
 impl RuntimeValue {
@@ -30,6 +32,7 @@ impl RuntimeValue {
             RuntimeValue::I64(_) => ir::types::I64,
             RuntimeValue::F32(_) => ir::types::F32,
             RuntimeValue::F64(_) => ir::types::F64,
+            RuntimeValue::V128(_) => ir::types::I8X16,
         }
     }
 
@@ -83,6 +86,7 @@ impl fmt::Display for RuntimeValue {
             RuntimeValue::I64(x) => write!(f, "{}: i64", x),
             RuntimeValue::F32(x) => write!(f, "{}: f32", x),
             RuntimeValue::F64(x) => write!(f, "{}: f64", x),
+            RuntimeValue::V128(x) => write!(f, "{:?}: v128", x.to_vec()),
         }
     }
 }
@@ -174,6 +178,7 @@ pub fn invoke(
                 RuntimeValue::I64(x) => ptr::write(ptr as *mut i64, *x),
                 RuntimeValue::F32(x) => ptr::write(ptr as *mut u32, *x),
                 RuntimeValue::F64(x) => ptr::write(ptr as *mut u64, *x),
+                RuntimeValue::V128(x) => ptr::write(ptr as *mut [u8; 16], *x),
             }
         }
     }
@@ -210,6 +215,7 @@ pub fn invoke(
                 ir::types::I64 => RuntimeValue::I64(ptr::read(ptr as *const i64)),
                 ir::types::F32 => RuntimeValue::F32(ptr::read(ptr as *const u32)),
                 ir::types::F64 => RuntimeValue::F64(ptr::read(ptr as *const u64)),
+                ir::types::I8X16 => RuntimeValue::V128(ptr::read(ptr as *const [u8; 16])),
                 other => panic!("unsupported value type {:?}", other),
             }
         })

--- a/wasmtime-jit/src/context.rs
+++ b/wasmtime-jit/src/context.rs
@@ -107,6 +107,11 @@ impl Context {
         Self::new(Box::new(Compiler::new(isa)))
     }
 
+    /// Retrieve the context features
+    pub fn features(&self) -> &Features {
+        &self.features
+    }
+
     /// Construct a new instance with the given features from the current `Context`
     pub fn with_features(self, features: Features) -> Self {
         Self { features, ..self }

--- a/wasmtime-runtime/src/lib.rs
+++ b/wasmtime-runtime/src/lib.rs
@@ -55,8 +55,8 @@ pub use crate::trap_registry::{get_mut_trap_registry, get_trap_registry, TrapReg
 pub use crate::traphandlers::{wasmtime_call, wasmtime_call_trampoline};
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
-    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMSharedSignatureIndex, VMTableDefinition,
-    VMTableImport,
+    VMGlobalImport, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport, VMSharedSignatureIndex,
+    VMTableDefinition, VMTableImport,
 };
 
 /// Version number of this crate.

--- a/wasmtime-runtime/src/vmcontext.rs
+++ b/wasmtime-runtime/src/vmcontext.rs
@@ -252,8 +252,8 @@ mod test_vmtable_definition {
 #[derive(Debug, Copy, Clone)]
 #[repr(C, align(8))]
 pub struct VMGlobalDefinition {
-    storage: [u8; 8],
-    // If more elements are added here, remember to add offset_of tests below!
+    storage: [u8; 8], // TODO this may need to be 16
+                      // If more elements are added here, remember to add offset_of tests below!
 }
 
 #[cfg(test)]

--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -17,7 +17,7 @@ cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
-wabt = "0.9.1"
+wabt = "0.9.2"
 target-lexicon = "0.8.1"
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }

--- a/wasmtime-wast/src/wast.rs
+++ b/wasmtime-wast/src/wast.rs
@@ -15,7 +15,7 @@ fn runtime_value(v: Value) -> RuntimeValue {
         Value::I64(x) => RuntimeValue::I64(x),
         Value::F32(x) => RuntimeValue::F32(x.to_bits()),
         Value::F64(x) => RuntimeValue::F64(x.to_bits()),
-        Value::V128(_) => unimplemented!("SIMD"),
+        Value::V128(x) => RuntimeValue::V128(x.to_le_bytes()),
     }
 }
 
@@ -374,6 +374,15 @@ impl WastContext {
                                             });
                                         }
                                     }
+                                    RuntimeValue::V128(_) => {
+                                        return Err(WastFileError {
+                                            filename: filename.to_string(),
+                                            line,
+                                            error: WastError::Type(format!(
+                                                "unexpected vector type in NaN test"
+                                            )),
+                                        });
+                                    }
                                 };
                             }
                         }
@@ -425,6 +434,15 @@ impl WastContext {
                                                 )),
                                             });
                                         }
+                                    }
+                                    RuntimeValue::V128(_) => {
+                                        return Err(WastFileError {
+                                            filename: filename.to_string(),
+                                            line,
+                                            error: WastError::Type(format!(
+                                                "unexpected vector type in NaN test",
+                                            )),
+                                        });
                                     }
                                 };
                             }


### PR DESCRIPTION
This change will allow us to verify that the SIMD implementation matches what is expected in the spec tests published to https://github.com/WebAssembly/simd/tree/master/test/core/simd. Some notes:
 - it depends on the changes in https://github.com/CraneStation/cranelift/pull/992; when these are published as a new cranelift version, 7848f68 should go away
 - it depends on an updated version of wabt-rs to fix a SIMD parsing bug; once https://github.com/pepyakin/wabt-rs/pull/56 is merged, 07541d0 should go away
 - it adds a way to run a single spec test in `build.rs` and enables SIMD for spec tests
 - it adds SIMD support throughout wasmtime
This is a work in progress.