### PR TITLE
Updating link to Fuchsia blog post

### DIFF
--- a/docs/WASI-capabilities.md
+++ b/docs/WASI-capabilities.md
@@ -78,4 +78,4 @@ https://github.com/NuxiNL/cloudabi#capability-based-security
 
 The Fuchsia project has a blog post on the topic of capability-based OS security:
 
-https://fuchsia.googlesource.com/docs/+/HEAD/the-book/dotdot.md
+https://fuchsia.googlesource.com/fuchsia/+/master/docs/the-book/dotdot.md


### PR DESCRIPTION
Visiting the old link results in an `Obsolete` message.