### PR TITLE
Replace `println` error handling.

### DIFF
--- a/wasmtime-wasi-c/src/translate.rs
+++ b/wasmtime-wasi-c/src/translate.rs
@@ -26,19 +26,19 @@ unsafe fn decode_ptr(
                 let last = match (ptr as usize).checked_add(len - 1) {
                     Some(sum) => sum,
                     None => {
-                        println!("!!! overflow");
+                        debug!("overflow in decode_ptr");
                         return Err(host::__WASI_EFAULT as host::__wasi_errno_t);
                     }
                 };
                 // Check for out of bounds.
                 if last >= (*definition).current_length {
-                    println!("!!! out of bounds");
+                    debug!("out of bounds in decode_ptr");
                     return Err(host::__WASI_EFAULT as host::__wasi_errno_t);
                 }
             }
             // Check alignment.
             if (ptr as usize) % align != 0 {
-                println!("!!! bad alignment: {} % {}", ptr, align);
+                debug!("bad alignment in decode_ptr: {} % {}", ptr, align);
                 return Err(host::__WASI_EINVAL as host::__wasi_errno_t);
             }
             // Ok, translate the address.
@@ -47,8 +47,8 @@ unsafe fn decode_ptr(
         // No export named "memory", or the export isn't a memory.
         // FIXME: Is EINVAL the best code here?
         x => {
-            println!(
-                "!!! no export named \"memory\", or the export isn't a mem: {:?}",
+            error!(
+                "no export named \"memory\", or the export isn't a mem: {:?}",
                 x
             );
             Err(host::__WASI_EINVAL as host::__wasi_errno_t)

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -1,5 +1,5 @@
 use cranelift_codegen::ir::types::{Type, I32, I64};
-use log::trace;
+use log::{error, trace};
 use wasi_common::{hostcalls, wasm32, WasiCtx};
 use wasmtime_runtime::{Export, VMContext};
 
@@ -76,10 +76,10 @@ impl AbiRet for () {
 
 fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasm32::__wasi_errno_t> {
     unsafe {
-        vmctx.host_state().downcast_mut::<WasiCtx>().ok_or_else(|| {
-            panic!("no host state named WasiCtx available");
-            wasm32::__WASI_EINVAL
-        })
+        vmctx
+            .host_state()
+            .downcast_mut::<WasiCtx>()
+            .ok_or_else(|| panic!("no host state named WasiCtx available"))
     }
 }
 

--- a/wasmtime-wasi/src/syscalls.rs
+++ b/wasmtime-wasi/src/syscalls.rs
@@ -77,7 +77,7 @@ impl AbiRet for () {
 fn get_wasi_ctx(vmctx: &mut VMContext) -> Result<&mut WasiCtx, wasm32::__wasi_errno_t> {
     unsafe {
         vmctx.host_state().downcast_mut::<WasiCtx>().ok_or_else(|| {
-            println!("!!! no host state named WasiCtx available");
+            panic!("no host state named WasiCtx available");
             wasm32::__WASI_EINVAL
         })
     }
@@ -95,8 +95,8 @@ fn get_memory(vmctx: &mut VMContext) -> Result<&mut [u8], wasm32::__wasi_errno_t
                 (*definition).current_length,
             )),
             x => {
-                println!(
-                    "!!! no export named \"memory\", or the export isn't a mem: {:?}",
+                error!(
+                    "no export named \"memory\", or the export isn't a mem: {:?}",
                     x
                 );
                 Err(wasm32::__WASI_EINVAL)


### PR DESCRIPTION
Use `panic!` and log macros for error handling instead of `println!`.