### PR TITLE
Fix opt_level setting passed to cranelift

### DIFF
--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -278,7 +278,7 @@ fn rmain() -> Result<(), Error> {
 
     // Enable optimization if requested.
     if args.flag_optimize {
-        flag_builder.set("opt_level", "best")?;
+        flag_builder.set("opt_level", "speed")?;
     }
 
     let config = Config::new(settings::Flags::new(flag_builder), features, debug_info);


### PR DESCRIPTION
With https://github.com/CraneStation/cranelift/commit/92a19e9398a0413ac598537c3dbea3a3699f45a1 the optimisation levels of cranelift were renamed, without this change trying to use the -o flag on wasmtime runtime results in "error: Unexpected value for a setting, expected any among none, speed, speed_and_size".

"best" was renamed "speed_and_size", although I think "speed" is more adapted to wastime.

Bye,
JB.