### PR TITLE
Fix lightbeam build by updating support for the compiler trait

### DIFF
--- a/wasmtime-environ/src/lightbeam.rs
+++ b/wasmtime-environ/src/lightbeam.rs
@@ -1,11 +1,12 @@
 //! Support for compiling with Lightbeam.
-
-use crate::compilation::{AddressTransforms, Compilation, CompileError, Relocations};
+use crate::address_map::{ModuleAddressMap, ValueLabelsRanges};
+use crate::compilation::{Compilation, CompileError, Relocations, Traps};
 use crate::func_environ::FuncEnvironment;
 use crate::module::Module;
 use crate::module_environ::FunctionBodyData;
 // TODO: Put this in `compilation`
 use crate::cranelift::RelocSink;
+use cranelift_codegen::ir;
 use cranelift_codegen::isa;
 use cranelift_entity::{PrimaryMap, SecondaryMap};
 use cranelift_wasm::DefinedFuncIndex;
@@ -23,7 +24,17 @@ impl crate::compilation::Compiler for Lightbeam {
         isa: &dyn isa::TargetIsa,
         // TODO
         _generate_debug_info: bool,
-    ) -> Result<(Compilation, Relocations, AddressTransforms), CompileError> {
+    ) -> Result<
+        (
+            Compilation,
+            Relocations,
+            ModuleAddressMap,
+            ValueLabelsRanges,
+            PrimaryMap<DefinedFuncIndex, ir::StackSlots>,
+            Traps,
+        ),
+        CompileError,
+    > {
         let env = FuncEnvironment::new(isa.frontend_config(), module);
         let mut relocations = PrimaryMap::new();
         let mut codegen_session: lightbeam::CodeGenSession<_> =
@@ -57,7 +68,10 @@ impl crate::compilation::Compiler for Lightbeam {
         Ok((
             Compilation::from_buffer(code_section.buffer().to_vec(), code_section_ranges_and_jt),
             relocations,
-            AddressTransforms::new(),
+            PrimaryMap::new(),
+            PrimaryMap::new(),
+            PrimaryMap::new(),
+            PrimaryMap::new(),
         ))
     }
 }


### PR DESCRIPTION
Updates support for the compiler trait for lightbeam. The change
coincides with a proposed update of lightbeam requiring
cranelift-codegen version "0.44"