### PR TITLE
Rename "always_lightbeam" to "lightbeam" in more places.

### DIFF
--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -74,8 +74,8 @@ struct Args {
     flag_cache_config: Option<String>,
     flag_create_cache_config: bool,
     flag_enable_simd: bool,
-    flag_always_lightbeam: bool,
-    flag_always_cranelift: bool,
+    flag_lightbeam: bool,
+    flag_cranelift: bool,
 }
 
 fn main() {
@@ -154,8 +154,7 @@ fn main() {
     }
 
     // Decide how to compile.
-    let strategy =
-        pick_compilation_strategy(args.flag_always_cranelift, args.flag_always_lightbeam);
+    let strategy = pick_compilation_strategy(args.flag_cranelift, args.flag_lightbeam);
 
     let isa = isa_builder.finish(settings::Flags::new(flag_builder));
     let engine = Compiler::new(isa, strategy);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,8 @@
 use wasmtime_jit::CompilationStrategy;
 
-pub fn pick_compilation_strategy(
-    always_cranelift: bool,
-    always_lightbeam: bool,
-) -> CompilationStrategy {
+pub fn pick_compilation_strategy(cranelift: bool, lightbeam: bool) -> CompilationStrategy {
     // Decide how to compile.
-    match (always_lightbeam, always_cranelift) {
+    match (lightbeam, cranelift) {
         #[cfg(feature = "lightbeam")]
         (true, false) => CompilationStrategy::Lightbeam,
         #[cfg(not(feature = "lightbeam"))]


### PR DESCRIPTION
The options are named "--lightbeam" and "--cranelift", so use those names consistently now.