### PR TITLE
Don't run the spec_testsuite tests if the submodule isn't checked out.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn main() {
         #[cfg(feature = "lightbeam")]
         "Lightbeam",
     ] {
+        writeln!(out, "#[cfg(test)]").expect("generating tests");
         writeln!(out, "#[allow(non_snake_case)]").expect("generating tests");
         writeln!(out, "mod {} {{", strategy).expect("generating tests");
 
@@ -95,7 +96,6 @@ fn start_test_module(out: &mut File, testsuite: &str) -> io::Result<()> {
             .expect("testsuite filename should be representable as a string")
             .replace("-", "_"),
     )?;
-    writeln!(out, "        #[cfg(test)]")?;
     writeln!(
         out,
         "        use super::super::{{native_isa, Path, WastContext, Compiler, Features, CompilationStrategy}};"

--- a/build.rs
+++ b/build.rs
@@ -24,12 +24,19 @@ fn main() {
 
         test_directory(&mut out, "misc_testsuite", strategy).expect("generating tests");
         test_directory(&mut out, "spec_testsuite", strategy).expect("generating tests");
-        test_file(
-            &mut out,
-            "spec_testsuite/proposals/simd/simd_const.wast",
-            strategy,
-        )
-        .expect("generating tests");
+        // Skip running spec_testsuite tests if the submodule isn't checked out.
+        if read_dir("spec_testsuite")
+            .expect("reading testsuite directory")
+            .next()
+            .is_some()
+        {
+            test_file(
+                &mut out,
+                "spec_testsuite/proposals/simd/simd_const.wast",
+                strategy,
+            )
+            .expect("generating tests");
+        }
 
         writeln!(out, "}}").expect("generating tests");
     }
@@ -86,6 +93,7 @@ fn start_test_module(out: &mut File, testsuite: &str) -> io::Result<()> {
             .expect("testsuite filename should be representable as a string")
             .replace("-", "_"),
     )?;
+    writeln!(out, "        #[cfg(test)]")?;
     writeln!(
         out,
         "        use super::super::{{native_isa, Path, WastContext, Compiler, Features, CompilationStrategy}};"

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,8 @@ fn main() {
                 strategy,
             )
             .expect("generating tests");
+        } else {
+            println!("cargo:warning=The spec testsuite is disabled. To enable, run `git submodule update --remote`.");
         }
 
         writeln!(out, "}}").expect("generating tests");


### PR DESCRIPTION
This way, if someone checks out the repository without checking out the
submodules, they can still run "cargo test".

Also, fix a warning in the generated test runner code.