### PR TITLE
Update the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for a tutorial on compiling and running programs using WASI and wasmtime, as
 well as an overview of the filesystem sandboxing system.
 
 Wasmtime passes the [WebAssembly spec testsuite]. To run it, update the
-`spec_testsuite` submodue with `git submodule update --remote`, and it will
+`spec_testsuite` submodule with `git submodule update --remote`, and it will
 be run as part of `cargo test`.
 
 Wasmtime does not yet implement Spectre mitigations, however this is a subject

--- a/README.md
+++ b/README.md
@@ -1,50 +1,40 @@
 # Wasmtime: a WebAssembly Runtime.
 
-Wasmtime is a standalone wasm-only runtime for [WebAssembly], using the [Cranelift] JIT.
+Wasmtime is a standalone wasm-only optimizing runtime for [WebAssembly] and
+[WASI]. It runs WebAssembly code [outside of the Web], and can be used both
+as a command-line utility or as a library embedded in a larger application.
 
-It runs WebAssembly code [outside of the Web], and can be used both as a command-line
-utility or as a library embedded in a larger application.
+To get started, visit [wasmtime.dev](https://wasmtime.dev/).
 
 [WebAssembly]: https://webassembly.org/
-[Cranelift]: https://github.com/CraneStation/cranelift
+[WASI]: https://wasi.dev
 [outside of the Web]: https://webassembly.org/docs/non-web/
 
 [![Build Status](https://dev.azure.com/CraneStation/Wasmtime/_apis/build/status/CraneStation.wasmtime?branchName=master)](https://dev.azure.com/CraneStation/Wasmtime/_build/latest?definitionId=4&branchName=master)
 [![Gitter chat](https://badges.gitter.im/CraneStation/CraneStation.svg)](https://gitter.im/CraneStation/Lobby)
 ![Minimum rustc 1.37](https://img.shields.io/badge/rustc-1.37+-green.svg)
 
-Wasmtime passes the WebAssembly spec testsuite, and supports a new system
-API proposal called [WebAssembly System Interface], or WASI.
-
-Wasmtime includes a git submodule; in order to build it, it's necessary to
-obtain a full checkout, like this:
-```
-git clone --recurse-submodules https://github.com/CraneStation/wasmtime.git
-```
-
-To build an optimized version of Wasmtime, use Cargo:
-
-```
-cargo build --release
-```
-
 There are Rust, C, and C++ toolchains that can compile programs with WASI. See
 the [WASI intro][WASI intro] for more information, and the [WASI tutorial][WASI tutorial]
 for a tutorial on compiling and running programs using WASI and wasmtime, as
 well as an overview of the filesystem sandboxing system.
 
+Wasmtime passes the [WebAssembly spec testsuite]. To run it, update the
+`spec_testsuite` submodue with `git submodule update --remote`, and it will
+be run as part of `cargo test`.
+
 Wasmtime does not yet implement Spectre mitigations, however this is a subject
 of ongoing research.
 
+[WebAssembly spec testsuite]: https://github.com/WebAssembly/testsuite
 [CloudABI]: https://cloudabi.org/
 [WebAssembly System Interface]: docs/WASI-overview.md
 [WASI intro]: docs/WASI-intro.md
 [WASI tutorial]: docs/WASI-tutorial.md
 
 Additional goals for Wasmtime include:
- - Support a variety of host APIs (not just WASI Core), with fast calling sequences,
+ - Support a variety of host APIs (not just WASI), with fast calling sequences,
    and develop proposals for additional API modules to be part of WASI.
-   [Reference Sysroot](https://github.com/WebAssembly/reference-sysroot).
  - Implement the [proposed WebAssembly C API].
  - Facilitate testing, experimentation, and development around the [Cranelift] and
    [Lightbeam] JITs.


### PR DESCRIPTION
Feature the wasmtime.dev website, update WASI content.

With Lightbeam moving into the Wasmtime repo, it's no longer necessary
to use git submodules to build Wasmtime.