### PR TITLE
Update cranelift to 0.45.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 default-run = "wasmtime"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-native = "0.44.0"
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-native = "0.46.0"
 wasmtime-api = { path = "wasmtime-api" }
 wasmtime-debug = { path = "wasmtime-debug" }
 wasmtime-environ = { path = "wasmtime-environ" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,9 @@ cargo-fuzz = true
 [dependencies]
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-native = "0.44.0"
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-native = "0.46.0"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 wasmparser = { version = "0.39.1", default-features = false }
 binaryen = "0.5.0"

--- a/misc/wasmtime-py/Cargo.toml
+++ b/misc/wasmtime-py/Cargo.toml
@@ -12,11 +12,11 @@ name = "_wasmtime"
 crate-type = ["cdylib"]
 
 [dependencies]
-cranelift-codegen = "0.44.0"
-cranelift-native = "0.44.0"
-cranelift-entity = "0.44.0"
-cranelift-wasm = "0.44.0"
-cranelift-frontend = "0.44.0"
+cranelift-codegen = "0.46.0"
+cranelift-native = "0.46.0"
+cranelift-entity = "0.46.0"
+cranelift-wasm = "0.46.0"
+cranelift-frontend = "0.46.0"
 wasmtime-environ = { path = "../../wasmtime-environ" }
 wasmtime-interface-types = { path = "../../wasmtime-interface-types" }
 wasmtime-jit = { path = "../../wasmtime-jit" }

--- a/misc/wasmtime-rust/Cargo.toml
+++ b/misc/wasmtime-rust/Cargo.toml
@@ -12,8 +12,8 @@ test = false
 doctest = false
 
 [dependencies]
-cranelift-codegen = "0.44.0"
-cranelift-native = "0.44.0"
+cranelift-codegen = "0.46.0"
+cranelift-native = "0.46.0"
 failure = "0.1.5"
 wasmtime-interface-types = { path = "../../wasmtime-interface-types" }
 wasmtime-jit = { path = "../../wasmtime-jit" }

--- a/src/bin/wasm2obj.rs
+++ b/src/bin/wasm2obj.rs
@@ -238,7 +238,13 @@ fn handle_module(
     // Decide how to compile.
     let strategy = pick_compilation_strategy(cranelift, lightbeam);
 
-    let (module, lazy_function_body_inputs, lazy_data_initializers, target_config) = {
+    let (
+        module,
+        module_translation_state,
+        lazy_function_body_inputs,
+        lazy_data_initializers,
+        target_config,
+    ) = {
         let environ = ModuleEnvironment::new(isa.frontend_config(), tunables);
 
         let translation = environ
@@ -247,6 +253,7 @@ fn handle_module(
 
         (
             translation.module,
+            translation.translation_state,
             translation.function_body_inputs,
             translation.data_initializers,
             translation.target_config,
@@ -259,6 +266,7 @@ fn handle_module(
             CompilationStrategy::Auto | CompilationStrategy::Cranelift => {
                 Cranelift::compile_module(
                     &module,
+                    module_translation_state,
                     lazy_function_body_inputs,
                     &*isa,
                     generate_debug_info,

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -12,11 +12,11 @@ name = "wasmtime_api"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-native = "0.44.0"
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-frontend = "0.44.0"
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-native = "0.46.0"
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-frontend = "0.46.0"
 wasmtime-runtime = { path="../wasmtime-runtime" }
 wasmtime-environ = { path="../wasmtime-environ" }
 wasmtime-jit = { path="../wasmtime-jit" }

--- a/wasmtime-debug/Cargo.toml
+++ b/wasmtime-debug/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 [dependencies]
 gimli = "0.19.0"
 wasmparser = { version = "0.39.1" }
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 faerie = "0.11.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 target-lexicon = { version = "0.8.1", default-features = false }

--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 lightbeam = { path = "../lightbeam", optional = true }
 failure = { version = "0.1.3", default-features = false }
 failure_derive = { version = "0.1.3", default-features = false }
@@ -44,7 +44,7 @@ tempfile = "3"
 target-lexicon = { version = "0.8.1", default-features = false }
 pretty_env_logger = "0.3.0"
 rand = { version = "0.7.0", features = ["small_rng"] }
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde", "all-arch"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde", "all-arch"] }
 filetime = "0.2.7"
 
 [features]

--- a/wasmtime-environ/src/cranelift.rs
+++ b/wasmtime-environ/src/cranelift.rs
@@ -21,7 +21,7 @@ use cranelift_codegen::ir::ExternalName;
 use cranelift_codegen::isa;
 use cranelift_codegen::Context;
 use cranelift_entity::PrimaryMap;
-use cranelift_wasm::{DefinedFuncIndex, FuncIndex, FuncTranslator};
+use cranelift_wasm::{DefinedFuncIndex, FuncIndex, FuncTranslator, ModuleTranslationState};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
 /// Implementation of a relocation sink that just saves all the information for later
@@ -177,6 +177,7 @@ impl crate::compilation::Compiler for Cranelift {
     /// associated relocations.
     fn compile_module<'data, 'module>(
         module: &'module Module,
+        module_translation_state: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<DefinedFuncIndex, FunctionBodyData<'data>>,
         isa: &dyn isa::TargetIsa,
         generate_debug_info: bool,
@@ -226,6 +227,7 @@ impl crate::compilation::Compiler for Cranelift {
                         let mut trans = FuncTranslator::new();
                         trans
                             .translate(
+                                module_translation_state,
                                 input.data,
                                 input.module_offset,
                                 &mut context.func,

--- a/wasmtime-interface-types/Cargo.toml
+++ b/wasmtime-interface-types/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", default-features = false }
+cranelift-codegen = { version = "0.46.0", default-features = false }
 failure = { version = "0.1", default-features = false }
 walrus = "0.12.0"
 wasmparser = { version = "0.39.1", default-features = false }

--- a/wasmtime-jit/Cargo.toml
+++ b/wasmtime-jit/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-frontend = "0.44.0"
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-frontend = "0.46.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 wasmtime-runtime = { path = "../wasmtime-runtime", default-features = false }
 wasmtime-debug = { path = "../wasmtime-debug", default-features = false }

--- a/wasmtime-obj/Cargo.toml
+++ b/wasmtime-obj/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 wasmtime-environ = { path = "../wasmtime-environ" }
 faerie = "0.11.0"

--- a/wasmtime-runtime/Cargo.toml
+++ b/wasmtime-runtime/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 region = "2.0.0"
 lazy_static = "1.2.0"

--- a/wasmtime-wasi-c/Cargo.toml
+++ b/wasmtime-wasi-c/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 target-lexicon = "0.8.1"
 log = { version = "0.4.8", default-features = false }
 libc = "0.2.60"

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -14,9 +14,9 @@ wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "603f7a9"}
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 target-lexicon = "0.8.1"
 log = { version = "0.4.8", default-features = false }
 

--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-entity = { version = "0.44.0", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.44.0", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-entity = { version = "0.46.0", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.46.0", features = ["enable-serde"] }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }


### PR DESCRIPTION
Due to API changes in ModuleEnvironment, this also changes several lines of the implementation. This can be merged once a new version of cranelift is released with https://github.com/CraneStation/cranelift/pull/1125.