### PR TITLE
Fix deadlink to WASI API header

### DIFF
--- a/docs/WASI-documents.md
+++ b/docs/WASI-documents.md
@@ -7,7 +7,7 @@ For more detail on what WASI is, see [the overview](WASI-overview.md).
 
 For specifics on the API, see the [API documentation](https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-api.md).
 Additionally, a C header file describing the WASI API is
-[here](https://github.com/CraneStation/wasi-libc/blob/wasi/libc-bottom-half/headers/public/wasi/core.h).
+[here](https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/core.h).
 
 The WASI libc repository is [wasi-libc](https://github.com/CraneStation/wasi-libc/).
 


### PR DESCRIPTION
The `wasi` branch doesn't exist anymore, I guess now `master` is the right branch.