### PR TITLE
Add a missing api to the wasm C API

### DIFF
--- a/wasmtime-api/src/wasm.rs
+++ b/wasmtime-api/src/wasm.rs
@@ -859,6 +859,11 @@ pub unsafe extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> *mut wasm_val
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wasm_valtype_delete(vt: *mut wasm_valtype_t) {
+    drop(Box::from_raw(vt));
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wasm_byte_vec_new(
     out: *mut wasm_byte_vec_t,
     size: usize,


### PR DESCRIPTION
This was used when [prototyping] but I found it wasn't implemented yet!

[prototyping]: https://github.com/dtolnay/watt/issues/2#issuecomment-543007365