### PR TITLE
Add back wasmtime-wast support for V128

### DIFF
--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -17,7 +17,7 @@ cranelift-wasm = { version = "0.46.1", features = ["enable-serde"] }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
-wast = "2.0.0"
+wast = "3.0.0"
 target-lexicon = "0.8.1"
 failure = { version = "0.1.3", default-features = false }
 

--- a/wasmtime-wast/src/wast.rs
+++ b/wasmtime-wast/src/wast.rs
@@ -19,6 +19,7 @@ fn runtime_value(v: &wast::Expression<'_>) -> RuntimeValue {
         I64Const(x) => RuntimeValue::I64(*x),
         F32Const(x) => RuntimeValue::F32(x.bits),
         F64Const(x) => RuntimeValue::F64(x.bits),
+        V128Const(x) => RuntimeValue::V128(x.to_le_bytes()),
         other => panic!("couldn't convert {:?} to a runtime value", other),
     }
 }


### PR DESCRIPTION
Accidentally left removed #434 when I meant to add it back in! Updates
the `wast` crate dependency and adds support for translating
`v128.const` instructions to a `RuntimeValue`

Closes #441