### PR TITLE
wasmtime-api: reserve_exact on the correct vector

### DIFF
--- a/wasmtime-api/src/module.rs
+++ b/wasmtime-api/src/module.rs
@@ -91,7 +91,7 @@ fn read_imports_and_exports(
             }
             SectionCode::Function => {
                 let section = section.get_function_section_reader()?;
-                sigs.reserve_exact(section.get_count() as usize);
+                func_sig.reserve_exact(section.get_count() as usize);
                 for entry in section {
                     func_sig.push(entry?);
                 }


### PR DESCRIPTION
Fix what looks like a copy-paste issue in wasmtime-api/src/module.rs,
which led to calling reserve_exact on one vector before pushing that
many elements into another.