### PR TITLE
wasmtime-wast: Fix copy-pasted doc comment

### DIFF
--- a/wasmtime-wast/src/lib.rs
+++ b/wasmtime-wast/src/lib.rs
@@ -1,4 +1,4 @@
-//! JIT-style runtime for WebAssembly using Cranelift.
+//! Implementation of the WAST text format for wasmtime.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]


### PR DESCRIPTION
wasmtime-wast's main module had the same comment as wasmtime-jit's main
module; fix it to have its own doc comment.