### PR TITLE
Please don't hardcode `cargo +stable fmt` in test-all.sh

### DIFF
--- a/format-all.sh
+++ b/format-all.sh
@@ -9,4 +9,4 @@ cd "$topdir"
 # Make sure we can find rustfmt.
 export PATH="$PATH:$HOME/.cargo/bin"
 
-exec cargo +stable fmt --all -- "$@"
+exec cargo fmt --all -- "$@"

--- a/test-all.sh
+++ b/test-all.sh
@@ -22,7 +22,7 @@ function banner {
 
 # Run rustfmt if we have it.
 banner "Rust formatting"
-if cargo +stable fmt -- --version > /dev/null ; then
+if cargo fmt -- --version > /dev/null ; then
     if ! "$topdir/format-all.sh" --check ; then
         echo "Formatting diffs detected! Run \"cargo fmt --all\" to correct."
         exit 1
@@ -31,7 +31,7 @@ else
     echo "cargo-fmt not available; formatting not checked!"
     echo
     echo "If you are using rustup, rustfmt can be installed via"
-    echo "\"rustup component add --toolchain=stable rustfmt-preview\", or see"
+    echo "\"rustup component add rustfmt-preview\", or see"
     echo "https://github.com/rust-lang-nursery/rustfmt for more information."
 fi
 


### PR DESCRIPTION
test-all.sh hardcodes an invocation of `cargo +stable fmt`, rather than just using `cargo fmt`. This has three problems:

- The `+stable` syntax assumes a toolchain installed by rustup (to understand the `+` syntax).
- `+stable`, specifically, assumes a toolchain named "stable". (I have a toolchain "system" and a toolchain "nightly".)
- Most importantly, this attempts to run stable rustfmt, while the rest of `test-all.sh` uses the default toolchain. This prevents it from working even with (for instance) `RUSTUP_TOOLCHAIN=nightly ./test-all.sh` or `rustup right nightly ./test-all.sh`.

In my case, my system toolchain doesn't have `cargo fmt` or `rustfmt` available, and also isn't new enough to build wasmtime. The `nightly` toolchain is new enough and has `cargo fmt` and `rustfmt` available, so I tried to run `./test-all.sh` with that, only to run into this issue.

Please consider just running `cargo fmt` rather than `cargo +stable fmt`, to allow users to build with toolchain overrides.