### PR TITLE
Fix fuzz build

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-wasm = { version = "0.46.1", features = ["enable-serde"] }
 cranelift-native = "0.46.1"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 wasmparser = { version = "0.39.2", default-features = false }
-binaryen = "0.5.0"
+binaryen = "0.8.1"
 
 [features]
 default = ["wasmparser/core"]

--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -10,10 +10,10 @@ extern crate wasmtime_jit;
 
 use cranelift_codegen::settings;
 use wasmparser::validate;
-use wasmtime_jit::{instantiate, Compiler, NullResolver};
+use wasmtime_jit::{instantiate, CompilationStrategy, Compiler, NullResolver};
 
 fuzz_target!(|data: &[u8]| {
-    if !validate(data, None) {
+    if validate(data, None).is_err() {
         return;
     }
     let flag_builder = settings::builder();
@@ -21,7 +21,7 @@ fuzz_target!(|data: &[u8]| {
         panic!("host machine is not a supported target");
     });
     let isa = isa_builder.finish(settings::Flags::new(flag_builder));
-    let mut compiler = Compiler::new(isa);
+    let mut compiler = Compiler::new(isa, CompilationStrategy::Auto);
     let mut imports_resolver = NullResolver {};
     let _instance = instantiate(
         &mut compiler,

--- a/fuzz/fuzz_targets/instantiate_translated.rs
+++ b/fuzz/fuzz_targets/instantiate_translated.rs
@@ -9,7 +9,7 @@ extern crate wasmtime_environ;
 extern crate wasmtime_jit;
 
 use cranelift_codegen::settings;
-use wasmtime_jit::{instantiate, Compiler, NullResolver};
+use wasmtime_jit::{instantiate, CompilationStrategy, Compiler, NullResolver};
 
 fuzz_target!(|data: &[u8]| {
     let binaryen_module = binaryen::tools::translate_to_fuzz_mvp(data);
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
         panic!("host machine is not a supported target");
     });
     let isa = isa_builder.finish(settings::Flags::new(flag_builder));
-    let mut compiler = Compiler::new(isa);
+    let mut compiler = Compiler::new(isa, CompilationStrategy::Auto);
     let mut imports_resolver = NullResolver {};
     let _instance = instantiate(
         &mut compiler,


### PR DESCRIPTION
Update to binaryen 0.8.1, as 0.5.0 doesn't build on current systems.

Update to match API changes in wasmtime and wasmparser.