### PR TITLE
wasmtime-wasi-c: allow(non_snake_case) to suppress warnings on consecutive underscores

### DIFF
--- a/wasmtime-wasi-c/src/host.rs
+++ b/wasmtime-wasi-c/src/host.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types, dead_code)]
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
 
 include!(concat!(env!("OUT_DIR"), "/wasmtime_ssp.rs"));
 

--- a/wasmtime-wasi-c/src/wasm32.rs
+++ b/wasmtime-wasi-c/src/wasm32.rs
@@ -6,6 +6,7 @@
 //! and to
 
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![allow(dead_code)]
 
 // C types


### PR DESCRIPTION
wasmtime-wasi-c contains many bindgen-generated symbols like
bindgen_test_layout___wasi_event_t___wasi_event_u___wasi_event_u_fd_readwrite_t
that contain triple-underscores in them. rustc doesn't consider those
names snake-case and generates extensive warnings about them. Suppress
those warnings with allow(non_snake_case).