### PR TITLE
Implement registering JIT unwind information on Windows.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -206,38 +206,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             // ABI only has a single return register, so we need to wait on full
             // multi-value support in Cranelift.
             (_, _) if is_multi_value => true,
-
-            // Until Windows unwind information is added we must disable SIMD spec tests that trap.
-            (_, _) if testname.starts_with("simd") => return true,
-
-            ("spec_testsuite", "address") => true,
-            ("spec_testsuite", "align") => true,
-            ("spec_testsuite", "call") => true,
-            ("spec_testsuite", "call_indirect") => true,
-            ("spec_testsuite", "conversions") => true,
-            ("spec_testsuite", "elem") => true,
-            ("spec_testsuite", "fac") => true,
-            ("spec_testsuite", "func_ptrs") => true,
-            ("spec_testsuite", "globals") => true,
-            ("spec_testsuite", "i32") => true,
-            ("spec_testsuite", "i64") => true,
-            ("spec_testsuite", "f32") => true,
-            ("spec_testsuite", "f64") => true,
-            ("spec_testsuite", "if") => true,
-            ("spec_testsuite", "imports") => true,
-            ("spec_testsuite", "int_exprs") => true,
-            ("spec_testsuite", "linking") => true,
-            ("spec_testsuite", "memory_grow") => true,
-            ("spec_testsuite", "memory_trap") => true,
-            ("spec_testsuite", "resizing") => true,
-            ("spec_testsuite", "select") => true,
-            ("spec_testsuite", "skip_stack_guard_page") => true,
-            ("spec_testsuite", "start") => true,
-            ("spec_testsuite", "traps") => true,
-            ("spec_testsuite", "unreachable") => true,
-            ("spec_testsuite", "unwind") => true,
-            ("misc_testsuite", "misc_traps") => true,
-            ("misc_testsuite", "stack_overflow") => true,
             (_, _) => false,
         };
     }

--- a/wasmtime-api/src/trampoline/func.rs
+++ b/wasmtime-api/src/trampoline/func.rs
@@ -9,8 +9,7 @@ use cranelift_codegen::{binemit, ir, isa};
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_wasm::{DefinedFuncIndex, FuncIndex};
-//use target_lexicon::HOST;
-use wasmtime_environ::{Export, Module};
+use wasmtime_environ::{CompiledFunction, Export, Module};
 use wasmtime_jit::CodeMemory;
 use wasmtime_runtime::{InstanceHandle, VMContext, VMFunctionBody};
 
@@ -185,9 +184,16 @@ fn make_trampoline(
         )
         .expect("compile_and_emit");
 
+    let mut unwind_info = Vec::new();
+    context.emit_unwind_info(isa, &mut unwind_info);
+
     code_memory
-        .allocate_copy_of_byte_slice(&code_buf)
-        .expect("allocate_copy_of_byte_slice")
+        .allocate_for_function(&CompiledFunction {
+            body: code_buf,
+            jt_offsets: context.func.jt_offsets,
+            unwind_info,
+        })
+        .expect("allocate_for_function")
         .as_ptr()
 }
 

--- a/wasmtime-environ/src/cache/tests.rs
+++ b/wasmtime-environ/src/cache/tests.rs
@@ -1,7 +1,7 @@
 use super::config::tests::test_prolog;
 use super::*;
 use crate::address_map::{FunctionAddressMap, InstructionAddressMap};
-use crate::compilation::{CodeAndJTOffsets, Relocation, RelocationTarget, TrapInformation};
+use crate::compilation::{CompiledFunction, Relocation, RelocationTarget, TrapInformation};
 use crate::module::{MemoryPlan, MemoryStyle, Module};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -258,9 +258,10 @@ fn new_module_cache_data(rng: &mut impl Rng) -> ModuleCacheData {
                     *v = (j as u32) * 3 / 4
                 }
             });
-            CodeAndJTOffsets {
+            CompiledFunction {
                 body: (0..(i * 3 / 2)).collect(),
                 jt_offsets: sm,
+                unwind_info: (0..(i * 3 / 2)).collect(),
             }
         })
         .collect();

--- a/wasmtime-environ/src/lib.rs
+++ b/wasmtime-environ/src/lib.rs
@@ -46,8 +46,8 @@ pub use crate::address_map::{
 };
 pub use crate::cache::{create_new_config as cache_create_new_config, init as cache_init};
 pub use crate::compilation::{
-    Compilation, CompileError, Compiler, Relocation, RelocationTarget, Relocations,
-    TrapInformation, Traps,
+    Compilation, CompileError, CompiledFunction, Compiler, Relocation, RelocationTarget,
+    Relocations, TrapInformation, Traps,
 };
 pub use crate::cranelift::Cranelift;
 pub use crate::func_environ::BuiltinFunctionIndex;

--- a/wasmtime-environ/src/lightbeam.rs
+++ b/wasmtime-environ/src/lightbeam.rs
@@ -65,10 +65,11 @@ impl crate::compilation::Compiler for Lightbeam {
 
         // TODO pass jump table offsets to Compilation::from_buffer() when they
         // are implemented in lightbeam -- using empty set of offsets for now.
+        // TODO: pass an empty range for the unwind information until lightbeam emits it
         let code_section_ranges_and_jt = code_section
             .funcs()
             .into_iter()
-            .map(|r| (r, SecondaryMap::new()));
+            .map(|r| (r, SecondaryMap::new(), 0..0));
 
         Ok((
             Compilation::from_buffer(code_section.buffer().to_vec(), code_section_ranges_and_jt),

--- a/wasmtime-jit/Cargo.toml
+++ b/wasmtime-jit/Cargo.toml
@@ -25,6 +25,9 @@ target-lexicon = { version = "0.9.0", default-features = false }
 hashbrown = { version = "0.6.0", optional = true }
 wasmparser = { version = "0.39.2", default-features = false }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.7", features = ["winnt", "impl-default"] }
+
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-wasm/std", "wasmtime-environ/std", "wasmtime-debug/std", "wasmtime-runtime/std", "wasmparser/std"]

--- a/wasmtime-jit/src/function_table.rs
+++ b/wasmtime-jit/src/function_table.rs
@@ -1,0 +1,134 @@
+//! Runtime function table.
+//!
+//! This module is primarily used to track JIT functions on Windows for stack walking and unwind.
+
+/// Represents a runtime function table.
+///
+/// The runtime function table is not implemented for non-Windows target platforms.
+#[cfg(not(target_os = "windows"))]
+pub(crate) struct FunctionTable;
+
+#[cfg(not(target_os = "windows"))]
+impl FunctionTable {
+    /// Creates a new function table.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Returns the number of functions in the table, also referred to as its 'length'.
+    ///
+    /// For non-Windows platforms, the table will always be empty.
+    pub fn len(&self) -> usize {
+        0
+    }
+
+    /// Adds a function to the table based off of the start offset, end offset, and unwind offset.
+    ///
+    /// The offsets are from the "module base", which is provided when the table is published.
+    ///
+    /// For non-Windows platforms, this is a no-op.
+    pub fn add_function(&mut self, _start: u32, _end: u32, _unwind: u32) {}
+
+    /// Publishes the function table using the given base address.
+    ///
+    /// A published function table will automatically be deleted when it is dropped.
+    ///
+    /// For non-Windows platforms, this is a no-op.
+    pub fn publish(&mut self, _base_address: u64) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+/// Represents a runtime function table.
+///
+/// This is used to register JIT code with the operating system to enable stack walking and unwinding.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+pub(crate) struct FunctionTable {
+    functions: Vec<winapi::um::winnt::RUNTIME_FUNCTION>,
+    published: bool,
+}
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+impl FunctionTable {
+    /// Creates a new function table.
+    pub fn new() -> Self {
+        Self {
+            functions: Vec::new(),
+            published: false,
+        }
+    }
+
+    /// Returns the number of functions in the table, also referred to as its 'length'.
+    pub fn len(&self) -> usize {
+        self.functions.len()
+    }
+
+    /// Adds a function to the table based off of the start offset, end offset, and unwind offset.
+    ///
+    /// The offsets are from the "module base", which is provided when the table is published.
+    pub fn add_function(&mut self, start: u32, end: u32, unwind: u32) {
+        use winapi::um::winnt;
+
+        assert!(!self.published, "table has already been published");
+
+        let mut entry = winnt::RUNTIME_FUNCTION::default();
+
+        entry.BeginAddress = start;
+        entry.EndAddress = end;
+
+        unsafe {
+            *entry.u.UnwindInfoAddress_mut() = unwind;
+        }
+
+        self.functions.push(entry);
+    }
+
+    /// Publishes the function table using the given base address.
+    ///
+    /// A published function table will automatically be deleted when it is dropped.
+    pub fn publish(&mut self, base_address: u64) -> Result<(), String> {
+        use winapi::um::winnt;
+
+        if self.published {
+            return Err("function table was already published".into());
+        }
+
+        self.published = true;
+
+        if self.functions.is_empty() {
+            return Ok(());
+        }
+
+        unsafe {
+            // Windows heap allocations are 32-bit aligned, but assert just in case
+            assert!(
+                (self.functions.as_mut_ptr() as u64) % 4 == 0,
+                "function table allocation was not aligned"
+            );
+
+            if winnt::RtlAddFunctionTable(
+                self.functions.as_mut_ptr(),
+                self.functions.len() as u32,
+                base_address,
+            ) == 0
+            {
+                return Err("failed to add function table".into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for FunctionTable {
+    fn drop(&mut self) {
+        use winapi::um::winnt;
+
+        if self.published {
+            unsafe {
+                winnt::RtlDeleteFunctionTable(self.functions.as_mut_ptr());
+            }
+        }
+    }
+}

--- a/wasmtime-jit/src/lib.rs
+++ b/wasmtime-jit/src/lib.rs
@@ -34,6 +34,7 @@ mod action;
 mod code_memory;
 mod compiler;
 mod context;
+mod function_table;
 mod instantiate;
 mod link;
 mod namespace;

--- a/wasmtime-runtime/signalhandlers/SignalHandlers.hpp
+++ b/wasmtime-runtime/signalhandlers/SignalHandlers.hpp
@@ -13,7 +13,7 @@ extern "C" {
 
 int8_t CheckIfTrapAtAddress(const uint8_t* pc);
 // Record the Trap code and wasm bytecode offset in TLS somewhere
-void RecordTrap(const uint8_t* pc);
+void RecordTrap(const uint8_t* pc, bool reset_guard_page);
 
 void* EnterScope(void*);
 void LeaveScope(void*);


### PR DESCRIPTION
This PR implements registering unwind information for JIT functions on
Windows so that the operating system can both walk and unwind stacks containing
JIT frames.

Currently this only works with Cranelift as lightbeam does not emit unwind
information yet.

This PR also resets the stack guard page on Windows for stack overflow
exceptions, allowing reliable stack overflow traps.

With these changes, all previously disabled test suite tests (not including
the multi-value tests) on Windows are now passing.

Fixes #291.