### PR TITLE
Replace wasm32 with wasi and wasi32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime-obj = { path = "wasmtime-obj" }
 wasmtime-wast = { path = "wasmtime-wast" }
 wasmtime-wasi = { path = "wasmtime-wasi" }
 wasmtime-wasi-c = { path = "wasmtime-wasi-c", optional = true }
-wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "3a374d0"}
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
 docopt = "1.0.1"
 serde = { "version" = "1.0.94", features = ["derive"] }
 faerie = "0.11.0"

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -35,7 +35,7 @@ core = ["hashbrown/nightly", "cranelift-codegen/core", "cranelift-wasm/core", "w
 
 [dev-dependencies]
 # for wasmtime.rs
-wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "3a374d0"}
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
 docopt = "1.0.1"
 serde = { "version" = "1.0.94", features = ["derive"] }
 pretty_env_logger = "0.3.0"

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "3a374d0"}
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
 cranelift-codegen = { version = "0.46.1", features = ["enable-serde"] }
 cranelift-entity = { version = "0.46.1", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.46.1", features = ["enable-serde"] }


### PR DESCRIPTION
This commit syncs `wasmtime-wasi` crate with the latest refactoring applied to `wasi-common` crate. Namely, `wasm32` is replaced with two modules: `wasi` and `wasi32`. This change can be tracked via CraneStation/wasi-common#151.

~~**This PR depends on CraneStation/wasi-common#151.**~~