### PR TITLE
Add error message to failed WAST directives

### DIFF
--- a/src/bin/wast.rs
+++ b/src/bin/wast.rs
@@ -168,7 +168,7 @@ fn main() {
         wast_context
             .run_file(Path::new(&filename))
             .unwrap_or_else(|e| {
-                eprintln!("{}", e);
+                eprintln!("{:?}", e);
                 process::exit(1)
             });
     }


### PR DESCRIPTION
Prior to this change, not all errors for failed WAST directives were being printed. For example, on certain directives, `wast` would fail with a Cranelift verifier error but would only print out the location of the error, not the error message itself.