### PR TITLE
Use new `WasiCtxBuilder` types from wasi-common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime-obj = { path = "wasmtime-obj" }
 wasmtime-wast = { path = "wasmtime-wast" }
 wasmtime-wasi = { path = "wasmtime-wasi" }
 wasmtime-wasi-c = { path = "wasmtime-wasi-c", optional = true }
-wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "2fe3530"}
 docopt = "1.0.1"
 serde = { "version" = "1.0.94", features = ["derive"] }
 faerie = "0.12.0"

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -35,7 +35,7 @@ core = ["hashbrown/nightly", "cranelift-codegen/core", "cranelift-wasm/core", "w
 
 [dev-dependencies]
 # for wasmtime.rs
-wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "2fe3530"}
 docopt = "1.0.1"
 serde = { "version" = "1.0.94", features = ["derive"] }
 pretty_env_logger = "0.3.0"

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
+wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "2fe3530"}
 cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
 cranelift-entity = { version = "0.49", features = ["enable-serde"] }
 cranelift-wasm = { version = "0.49", features = ["enable-serde"] }

--- a/wasmtime-wasi/src/instantiate.rs
+++ b/wasmtime-wasi/src/instantiate.rs
@@ -102,12 +102,9 @@ pub fn instantiate_wasi(
     let signatures = PrimaryMap::new();
 
     let mut wasi_ctx_builder = WasiCtxBuilder::new()
-        .and_then(|ctx| ctx.inherit_stdio())
-        .and_then(|ctx| ctx.args(argv.iter()))
-        .and_then(|ctx| ctx.envs(environ.iter()))
-        .map_err(|err| {
-            InstantiationError::Resource(format!("couldn't assemble WASI context object: {}", err))
-        })?;
+        .inherit_stdio()
+        .args(argv)
+        .envs(environ);
 
     for (dir, f) in preopened_dirs {
         wasi_ctx_builder = wasi_ctx_builder.preopened_dir(


### PR DESCRIPTION
This updates uses of the `WasiCtxBuilder` type to be compatible with the changes I have proposed in https://github.com/CraneStation/wasi-common/pull/175. Unless/until that has merged, these changes don't make sense, so I'm marking this as a draft PR.