### PR TITLE
Bump Cranelift to 0.49.0 and target-lexicon to 0.9.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2018"
 default-run = "wasmtime"
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
-cranelift-native = { version = "0.47" }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
+cranelift-native = { version = "0.49" }
 wasmtime-api = { path = "wasmtime-api" }
 wasmtime-debug = { path = "wasmtime-debug" }
 wasmtime-environ = { path = "wasmtime-environ" }
@@ -30,7 +30,7 @@ docopt = "1.0.1"
 serde = { "version" = "1.0.94", features = ["derive"] }
 faerie = "0.11.0"
 anyhow = "1.0.19"
-target-lexicon = { version = "0.8.1", default-features = false }
+target-lexicon = { version = "0.9.0", default-features = false }
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.1"
 wat = "1.0.2"

--- a/cranelift-version.sh
+++ b/cranelift-version.sh
@@ -9,11 +9,11 @@ topdir=$(dirname "$0")
 cd "$topdir"
 
 # All the cranelift-* crates have the same version number
-version="0.44.0"
+version="0.49"
 
 # Update all of the Cargo.toml files.
 echo "Updating crate versions to $version"
-for crate in . wasmtime-* fuzz misc/wasmtime-*; do
+for crate in . lightbeam wasmtime-* fuzz misc/wasmtime-*; do
     # Update the version number of this crate to $version.
     sed -i.bk -e "/^cranelift-/s/\"[^\"]*\"/\"$version\"/" \
         "$crate/Cargo.toml"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,9 @@ cargo-fuzz = true
 [dependencies]
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
-cranelift-native = { version = "0.47" }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
+cranelift-native = { version = "0.49" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 wasmparser = { version = "0.39.2", default-features = false }
 binaryen = "0.8.1"

--- a/lightbeam/Cargo.toml
+++ b/lightbeam/Cargo.toml
@@ -18,7 +18,7 @@ memoffset = "0.5.1"
 itertools = "0.8"
 capstone = "0.6.0"
 thiserror = "1.0.4"
-cranelift-codegen = { version = "0.47" }
+cranelift-codegen = { version = "0.49" }
 multi_mut = "0.1"
 either = "1.5"
 typemap = "0.3"

--- a/misc/wasmtime-py/Cargo.toml
+++ b/misc/wasmtime-py/Cargo.toml
@@ -12,16 +12,16 @@ name = "_wasmtime"
 crate-type = ["cdylib"]
 
 [dependencies]
-cranelift-codegen = { version = "0.47" }
-cranelift-native = { version = "0.47" }
-cranelift-entity = { version = "0.47" }
-cranelift-wasm = { version = "0.47" }
-cranelift-frontend = { version = "0.47" }
+cranelift-codegen = { version = "0.49" }
+cranelift-native = { version = "0.49" }
+cranelift-entity = { version = "0.49" }
+cranelift-wasm = { version = "0.49" }
+cranelift-frontend = { version = "0.49" }
 wasmtime-environ = { path = "../../wasmtime-environ" }
 wasmtime-interface-types = { path = "../../wasmtime-interface-types" }
 wasmtime-jit = { path = "../../wasmtime-jit" }
 wasmtime-runtime = { path = "../../wasmtime-runtime" }
-target-lexicon = { version = "0.8.1", default-features = false }
+target-lexicon = { version = "0.9.0", default-features = false }
 anyhow = "1.0.19"
 region = "2.0.0"
 wasmparser = "0.39.2"

--- a/misc/wasmtime-rust/Cargo.toml
+++ b/misc/wasmtime-rust/Cargo.toml
@@ -12,8 +12,8 @@ test = false
 doctest = false
 
 [dependencies]
-cranelift-codegen = { version = "0.47" }
-cranelift-native = { version = "0.47" }
+cranelift-codegen = { version = "0.49" }
+cranelift-native = { version = "0.49" }
 wasmtime-interface-types = { path = "../../wasmtime-interface-types" }
 wasmtime-jit = { path = "../../wasmtime-jit" }
 wasmtime-rust-macro = { path = "./macro" }

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -12,16 +12,16 @@ name = "wasmtime_api"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-native = { version = "0.47" }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
-cranelift-frontend = { version = "0.47" }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-native = { version = "0.49" }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
+cranelift-frontend = { version = "0.49" }
 wasmtime-runtime = { path="../wasmtime-runtime" }
 wasmtime-environ = { path="../wasmtime-environ" }
 wasmtime-jit = { path="../wasmtime-jit" }
 wasmparser = { version = "0.39.2", default-features = false }
-target-lexicon = { version = "0.8.1", default-features = false }
+target-lexicon = { version = "0.9.0", default-features = false }
 anyhow = "1.0.19"
 thiserror = "1.0.4"
 region = "2.0.0"

--- a/wasmtime-debug/Cargo.toml
+++ b/wasmtime-debug/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2018"
 [dependencies]
 gimli = "0.19.0"
 wasmparser = "0.39.2"
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
 faerie = "0.11.0"
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
-target-lexicon = { version = "0.8.1", default-features = false }
+target-lexicon = { version = "0.9.0", default-features = false }
 failure = { version = "0.1.3", default-features = false }
 hashbrown = { version = "0.6.0", optional = true }
 thiserror = "1.0.4"

--- a/wasmtime-environ/Cargo.toml
+++ b/wasmtime-environ/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
 lightbeam = { path = "../lightbeam", optional = true }
 indexmap = "1.0.2"
 rayon = "1.1"
@@ -40,10 +40,10 @@ errno = "0.2.4"
 
 [dev-dependencies]
 tempfile = "3"
-target-lexicon = { version = "0.8.1", default-features = false }
+target-lexicon = { version = "0.9.0", default-features = false }
 pretty_env_logger = "0.3.0"
 rand = { version = "0.7.0", features = ["small_rng"] }
-cranelift-codegen = { version = "0.47", features = ["enable-serde", "all-arch"] }
+cranelift-codegen = { version = "0.49", features = ["enable-serde", "all-arch"] }
 filetime = "0.2.7"
 
 [features]

--- a/wasmtime-interface-types/Cargo.toml
+++ b/wasmtime-interface-types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.19"
-cranelift-codegen = { version = "0.47", default-features = false }
+cranelift-codegen = { version = "0.49", default-features = false }
 walrus = "0.13"
 wasmparser = { version = "0.39.2", default-features = false }
 wasm-webidl-bindings = "0.6"

--- a/wasmtime-jit/Cargo.toml
+++ b/wasmtime-jit/Cargo.toml
@@ -11,17 +11,17 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
-cranelift-frontend = { version = "0.47" }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
+cranelift-frontend = { version = "0.49" }
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 wasmtime-runtime = { path = "../wasmtime-runtime", default-features = false }
 wasmtime-debug = { path = "../wasmtime-debug", default-features = false }
 region = "2.0.0"
 failure = { version = "0.1.3", default-features = false }
 thiserror = "1.0.4"
-target-lexicon = { version = "0.8.1", default-features = false }
+target-lexicon = { version = "0.9.0", default-features = false }
 hashbrown = { version = "0.6.0", optional = true }
 wasmparser = { version = "0.39.2", default-features = false }
 

--- a/wasmtime-obj/Cargo.toml
+++ b/wasmtime-obj/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
 wasmtime-environ = { path = "../wasmtime-environ" }
 faerie = "0.11.0"

--- a/wasmtime-runtime/Cargo.toml
+++ b/wasmtime-runtime/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
 wasmtime-environ = { path = "../wasmtime-environ", default-features = false }
 region = "2.0.0"
 lazy_static = "1.2.0"

--- a/wasmtime-wasi-c/Cargo.toml
+++ b/wasmtime-wasi-c/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
-target-lexicon = "0.8.1"
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
+target-lexicon = "0.9.0"
 log = { version = "0.4.8", default-features = false }
 libc = "0.2.60"
 

--- a/wasmtime-wasi/Cargo.toml
+++ b/wasmtime-wasi/Cargo.toml
@@ -14,10 +14,10 @@ wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasi-common = { git = "https://github.com/CraneStation/wasi-common", rev = "37ce4ba"}
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
-target-lexicon = "0.8.1"
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
+target-lexicon = "0.9.0"
 log = { version = "0.4.8", default-features = false }
 
 [badges]

--- a/wasmtime-wast/Cargo.toml
+++ b/wasmtime-wast/Cargo.toml
@@ -11,15 +11,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { version = "0.47", features = ["enable-serde"] }
-cranelift-entity = { version = "0.47", features = ["enable-serde"] }
-cranelift-wasm = { version = "0.47", features = ["enable-serde"] }
+cranelift-codegen = { version = "0.49", features = ["enable-serde"] }
+cranelift-entity = { version = "0.49", features = ["enable-serde"] }
+cranelift-wasm = { version = "0.49", features = ["enable-serde"] }
 wasmtime-jit = { path = "../wasmtime-jit" }
 wasmtime-runtime = { path = "../wasmtime-runtime" }
 wasmtime-environ = { path = "../wasmtime-environ" }
 wast = "3.0.0"
 anyhow = "1.0.19"
-target-lexicon = "0.8.1"
+target-lexicon = "0.9.0"
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
This PR bumps Cranelift to 0.49.0 and target-lexicon to 0.9.0 to fix the
failing build to due an updated faerie crate that violated semver with an
updated 0.9.0 target-lexicon dependency.

Fixes #491.