### PR TITLE
Run beta/nightly test on ubuntu, not macos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,19 +65,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [stable, beta, nightly, windows, linux]
+        build: [stable, beta, nightly, windows, macos]
         include:
           - build: stable
-            os: macos-latest
+            os: ubuntu-latest
             rust: stable
           - build: beta
-            os: macos-latest
+            os: ubuntu-latest
             rust: beta
           - build: nightly
-            os: macos-latest
-            rust: nightly
-          - build: linux
             os: ubuntu-latest
+            rust: nightly
+          - build: macos
+            os: macos-latest
             rust: stable
           - build: windows
             os: windows-latest


### PR DESCRIPTION
This commit switches the beta/nightly tests to happen on Ubuntu instead
of macOS. Turns out GitHub Actions has scheduling limitations on macOS
that limit repositories to 5 concurrent jobs per repository, so let's
reduce the load a bit by running more builds on Linux than mac.