### PR TITLE
Simplify `#[test]` generation for `*.wast` files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ libc = "0.2.60"
 rayon = "1.1"
 wasm-webidl-bindings = "0.6"
 
+[build-dependencies]
+anyhow = "1.0.19"
+
 [workspace]
 members = [
   "misc/wasmtime-rust",

--- a/tests/wast_testsuites.rs
+++ b/tests/wast_testsuites.rs
@@ -9,7 +9,24 @@ use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
 
-#[cfg(test)]
+// Each of the tests included from `wast_testsuite_tests` will call this
+// function which actually executes the `wast` test suite given the `strategy`
+// to compile it.
+fn run_wast(wast: &str, strategy: CompilationStrategy) -> anyhow::Result<()> {
+    let wast = Path::new(wast);
+    let isa = native_isa();
+    let compiler = Compiler::new(isa, strategy);
+    let features = Features {
+        simd: wast.iter().any(|s| s == "simd"),
+        multi_value: wast.iter().any(|s| s == "multi-value"),
+        ..Default::default()
+    };
+    let mut wast_context = WastContext::new(Box::new(compiler)).with_features(features);
+    wast_context.register_spectest()?;
+    wast_context.run_file(wast)?;
+    Ok(())
+}
+
 fn native_isa() -> Box<dyn isa::TargetIsa> {
     let mut flag_builder = settings::builder();
     flag_builder.enable("enable_verifier").unwrap();


### PR DESCRIPTION
This commit simplifies the build script slightly for generating tests by
doing a few dull refactorings:

* Leaves formatting to `rustfmt`
* Extract bulk of code execution into a top-level shared `run_wast`
  function so each test is a one-liner
* Use `anyhow` for errors both in the script and in tests