### PR TITLE
Update the top-level README.md and embedding documentation.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
     - run: $CENTOS cargo build --release --bin wasmtime --bin wasm2obj
       shell: bash
     # Build `libwasmtime_api.so`
-    - run: $CENTOS cargo build --release --features wasm-c-api --manifest-path wasmtime-api/Cargo.toml
+    - run: $CENTOS cargo build --release --manifest-path wasmtime-api/Cargo.toml
       shell: bash
     # Test what we just built
     - run: $CENTOS cargo test --release --all --exclude lightbeam --exclude wasmtime-wasi-c --exclude wasmtime-py --exclude wasmtime-api

--- a/README.md
+++ b/README.md
@@ -35,34 +35,24 @@ of ongoing research.
 Additional goals for Wasmtime include:
  - Support a variety of host APIs (not just WASI), with fast calling sequences,
    and develop proposals for additional API modules to be part of WASI.
- - Implement the [proposed WebAssembly C API].
- - Facilitate testing, experimentation, and development around the [Cranelift] and
-   [Lightbeam] JITs.
+ - Facilitate development and testing around the [Cranelift] and [Lightbeam] JITs,
+   and other WebAssembly execution strategies.
  - Develop a native ABI used for compiling WebAssembly suitable for use in both
    JIT and AOT to native object files.
 
-[proposed WebAssembly C API]: https://github.com/rossberg/wasm-c-api
 [Cranelift]: https://github.com/CraneStation/cranelift
-[Lightbeam]: https://github.com/CraneStation/lightbeam
+[Lightbeam]: https://github.com/CraneStation/wasmtime/tree/master/lightbeam
 
 #### Including Wasmtime in your project
-Wasmtime exposes an API for JIT compilation through the `wasmtime-jit` subcrate, which depends on `wasmtime-environ` and `wasmtime-runtime` for the ABI and runtime support respectively. However, this API is not documented and subject to change. Please use at your own risk!
 
-Build the individual crates as such:
+Wasmtime exposes an API for embedding as a library through the `wasmtime-api` subcrate,
+which contains both a [high-level and safe Rust API], as well as a C-compatible API
+compatible with the [proposed WebAssembly C API].
 
-```
-cargo build --package wasmtime-jit
-```
+For more information, see the [Rust API embedding chapter] of the Wasmtime documentation.
 
-Wasmtime does not currently publish these crates on crates.io. They may be included as a git dependency, like this:
-
-```toml
-[dependencies]
-wasmtime-environ = { git = "https://github.com/CraneStation/wasmtime", rev = "somecommithash" }
-wasmtime-runtime = { git = "https://github.com/CraneStation/wasmtime", rev = "somecommithash" }
-wasmtime-jit = { git = "https://github.com/CraneStation/wasmtime", rev = "somecommithash" }
-```
-
-All three crates must be specified as dependencies for `wasmtime-jit` to build correctly, at the moment.
+[high-level and safe Rust API]: https://docs.rs/wasmtime-api/
+[proposed WebAssembly C API]: https://github.com/rossberg/wasm-c-api
+[Rust API embedding chapter]: https://cranestation.github.io/wasmtime/embed-rust.html
 
 It's Wasmtime.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ compatible with the [proposed WebAssembly C API].
 For more information, see the [Rust API embedding chapter] of the Wasmtime documentation.
 
 [high-level and safe Rust API]: https://docs.rs/wasmtime-api/
-[proposed WebAssembly C API]: https://github.com/rossberg/wasm-c-api
+[proposed WebAssembly C API]: https://github.com/WebAssembly/wasm-c-api
 [Rust API embedding chapter]: https://cranestation.github.io/wasmtime/embed-rust.html
 
 It's Wasmtime.

--- a/wasmtime-api/Cargo.toml
+++ b/wasmtime-api/Cargo.toml
@@ -30,7 +30,6 @@ hashbrown = { version = "0.6.0", optional = true }
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-wasm/std", "wasmtime-environ/std", "wasmparser/std"]
-wasm-c-api = []
 core = ["hashbrown/nightly", "cranelift-codegen/core", "cranelift-wasm/core", "wasmtime-environ/core", "wasmparser/core"]
 
 [dev-dependencies]

--- a/wasmtime-api/c-examples/Makefile
+++ b/wasmtime-api/c-examples/Makefile
@@ -46,9 +46,9 @@ WASM_CC_LIBS = $(error unsupported C++)
 
 # Compiler config
 ifeq (${WASMTIME_API_MODE},release)
-  CARGO_BUILD_FLAGS = --features "wasm-c-api" --release
+  CARGO_BUILD_FLAGS = --release
 else
-  CARGO_BUILD_FLAGS = --features "wasm-c-api"
+  CARGO_BUILD_FLAGS =
 endif
 
 ifeq (${C_COMP},clang)

--- a/wasmtime-api/src/lib.rs
+++ b/wasmtime-api/src/lib.rs
@@ -14,7 +14,6 @@ mod trap;
 mod types;
 mod values;
 
-#[cfg(feature = "wasm-c-api")]
 pub mod wasm;
 
 #[macro_use]


### PR DESCRIPTION
wasmtime-api is now the primary external API crate, so recommend that
instead of wasmtime-jit.

Also, enable wasmtime-api's C API by default, so that it shows up on
docs.rs, and to make it easier to use.

And, add basic embedding documentation and link to it from the
README.md. Credit to @yurydelendik for the content.