### PR TITLE
Adds WASI support to markdown rust example.

### DIFF
--- a/misc/wasmtime-rust/Cargo.toml
+++ b/misc/wasmtime-rust/Cargo.toml
@@ -17,4 +17,5 @@ cranelift-native = { version = "0.49" }
 wasmtime-interface-types = { path = "../../wasmtime-interface-types" }
 wasmtime-jit = { path = "../../wasmtime-jit" }
 wasmtime-rust-macro = { path = "./macro" }
+wasmtime-wasi = { path = "../../wasmtime-wasi" }
 anyhow = "1.0.19"

--- a/misc/wasmtime-rust/macro/src/lib.rs
+++ b/misc/wasmtime-rust/macro/src/lib.rs
@@ -64,6 +64,16 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
                 ..Default::default()
             });
             let data = #root::wasmtime_interface_types::ModuleData::new(&bytes)?;
+            if let Some(wasi_name) = data.has_wasi() {
+                let wasi_handle = wasmtime_wasi::instantiate_wasi(
+                    "",
+                    cx.get_global_exports(),
+                    &[],
+                    &[],
+                    &[],
+                ).expect("wasi support");
+                cx.name_instance(wasi_name, wasi_handle);
+            }
             let handle = cx.instantiate_module(None, &bytes)?;
 
             Ok(#name { cx, handle, data })

--- a/misc/wasmtime-rust/macro/src/lib.rs
+++ b/misc/wasmtime-rust/macro/src/lib.rs
@@ -64,15 +64,15 @@ fn generate_load(item: &syn::ItemTrait) -> syn::Result<TokenStream> {
                 ..Default::default()
             });
             let data = #root::wasmtime_interface_types::ModuleData::new(&bytes)?;
-            if let Some(wasi_name) = data.has_wasi() {
+            if let Some(module_name) = data.find_wasi_module_name() {
                 let wasi_handle = wasmtime_wasi::instantiate_wasi(
                     "",
                     cx.get_global_exports(),
                     &[],
                     &[],
                     &[],
-                ).expect("wasi support");
-                cx.name_instance(wasi_name, wasi_handle);
+                )?;
+                cx.name_instance(module_name, wasi_handle);
             }
             let handle = cx.instantiate_module(None, &bytes)?;
 

--- a/wasmtime-interface-types/src/lib.rs
+++ b/wasmtime-interface-types/src/lib.rs
@@ -100,6 +100,20 @@ impl ModuleData {
         })
     }
 
+    /// Detects if WASI support is needed: returns module name that is requested.
+    pub fn has_wasi(&self) -> Option<String> {
+        self.inner.as_ref().and_then(|Inner { module }| {
+            module
+                .imports
+                .iter()
+                .find(|walrus::Import { module, .. }| match module.as_str() {
+                    "wasi" | "wasi_unstable" => true,
+                    _ => false,
+                })
+                .map(|walrus::Import { module, .. }| module.clone())
+        })
+    }
+
     /// Same as `Context::invoke` except that this works with a `&[Value]` list
     /// instead of a `&[RuntimeValue]` list. (in this case `Value` is the set of
     /// wasm interface types)

--- a/wasmtime-interface-types/src/lib.rs
+++ b/wasmtime-interface-types/src/lib.rs
@@ -101,7 +101,7 @@ impl ModuleData {
     }
 
     /// Detects if WASI support is needed: returns module name that is requested.
-    pub fn has_wasi(&self) -> Option<String> {
+    pub fn find_wasi_module_name(&self) -> Option<String> {
         self.inner.as_ref().and_then(|Inner { module }| {
             module
                 .imports


### PR DESCRIPTION
The wasm files + interface types can be compiled for wasm32-wasi target (e.g. via cargo wasi). That can add some "wasi_unstable" dependecies. In most of the cases it is panic error printing or random number initialization.

This PR allows markdown example to be executed even if wasm file contains "wasi_unstable" imports.