### PR TITLE
Add a `keywords` field to Cargo.toml files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
 categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
 repository = "https://github.com/CraneStation/wasmtime"
 edition = "2018"
 default-run = "wasmtime"

--- a/crates/misc/py/Cargo.toml
+++ b/crates/misc/py/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Wasmtime Project Developers"]
 description = "Python extension for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 categories = ["wasm", "python"]
+keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [lib]

--- a/crates/misc/rust/Cargo.toml
+++ b/crates/misc/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 categories = ["wasm", "rust"]
+keywords = ["webassembly", "wasm"]
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Rust extension for Wasmtime"
 

--- a/crates/wasi-c/Cargo.toml
+++ b/crates/wasi-c/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
 repository = "https://github.com/CraneStation/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["The Cranelift Project Developers"]
 description = "WASI API support for Wasmtime"
 categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
 repository = "https://github.com/CraneStation/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"


### PR DESCRIPTION
Unclear how meaningful these are, but some of our crates have these and others didn't, so it seemed best to be consistent.