### PR TITLE
Reduce duplication in error messages

### DIFF
--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -152,11 +152,11 @@ pub type Traps = PrimaryMap<DefinedFuncIndex, Vec<TrapInformation>>;
 #[derive(Error, Debug)]
 pub enum CompileError {
     /// A wasm translation error occured.
-    #[error("WebAssembly translation error: {0}")]
+    #[error("WebAssembly translation error")]
     Wasm(#[from] WasmError),
 
     /// A compilation error occured.
-    #[error("Compilation error: {0}")]
+    #[error("Compilation error")]
     Codegen(#[from] CodegenError),
 
     /// A compilation error occured.

--- a/crates/jit/src/action.rs
+++ b/crates/jit/src/action.rs
@@ -114,7 +114,7 @@ pub enum ActionOutcome {
 #[derive(Error, Debug)]
 pub enum ActionError {
     /// An internal implementation error occurred.
-    #[error("{0}")]
+    #[error("Failed to setup a module")]
     Setup(#[from] SetupError),
 
     /// No field with the specified name was present.

--- a/crates/jit/src/context.rs
+++ b/crates/jit/src/context.rs
@@ -23,10 +23,10 @@ pub struct UnknownInstance {
 #[derive(Error, Debug)]
 pub enum ContextError {
     /// An unknown instance name was used.
-    #[error("{0}")]
+    #[error("An error occured due to an unknown instance being specified")]
     Instance(#[from] UnknownInstance),
     /// An error occured while performing an action.
-    #[error("{0}")]
+    #[error("An error occurred while performing an action")]
     Action(#[from] ActionError),
 }
 

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -35,12 +35,12 @@ pub enum SetupError {
     Validate(String),
 
     /// A wasm translation error occured.
-    #[error("WebAssembly compilation error: {0}")]
+    #[error("WebAssembly failed to compile")]
     Compile(#[from] CompileError),
 
     /// Some runtime resource was unavailable or insufficient, or the start function
     /// trapped.
-    #[error("Instantiation error: {0}")]
+    #[error("Instantiation failed during setup")]
     Instantiate(#[from] InstantiationError),
 
     /// Debug information generation error occured.

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1288,7 +1288,7 @@ pub enum InstantiationError {
     Resource(String),
 
     /// A wasm link error occured.
-    #[error("{0}")]
+    #[error("Failed to link module")]
     Link(#[from] LinkError),
 
     /// A compilation error occured.

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -310,7 +310,7 @@ impl WastContext {
                         Ok(()) => bail!("{}\nexpected module to fail to build", context(span)),
                         Err(e) => e,
                     };
-                    let error_message = err.to_string();
+                    let error_message = format!("{:?}", err);
                     if !error_message.contains(&message) {
                         // TODO: change to bail!
                         println!(
@@ -339,7 +339,7 @@ impl WastContext {
                         }
                         Err(e) => e,
                     };
-                    let error_message = err.to_string();
+                    let error_message = format!("{:?}", err);
                     if !error_message.contains(&message) {
                         // TODO: change to bail!
                         println!(
@@ -360,7 +360,7 @@ impl WastContext {
                         Ok(()) => bail!("{}\nexpected module to fail to link", context(span)),
                         Err(e) => e,
                     };
-                    let error_message = err.to_string();
+                    let error_message = format!("{:?}", err);
                     if !error_message.contains(&message) {
                         bail!(
                             "{}\nassert_unlinkable: expected {}, got {}",


### PR DESCRIPTION
This commit removes duplication in error messages where the same text
would show up multiple times in a fully rendered error message.

When using `derive(Error)` when the `#[from]` attribute is used there's
no need to also render that payload into the error string because the
`#[from]` establishes a "backtrace" which means that when the full
context of an error is rendered it will include the `#[from]` in the
lower frames of the backtrace anyway.

This commit audits the `derive(Error)` implementations to avoid
duplication in the rendered error messages, ensuring that if `#[from]`
is used then the `#[from]` field isn't also rendered in the textual
description.