### PR TITLE
Dynamically load utimensat if exists on the host

### DIFF
--- a/crates/wasi-common/src/sys/unix/bsd/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/filetime.rs
@@ -15,28 +15,16 @@ cfg_if! {
             target_os = "dragonfly"
     ))] {
         pub(crate) const UTIME_NOW: i64 = -1;
-    } else if #[cfg(target_os = "openbsd")] {
-        // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
-        pub(crate) const UTIME_NOW: i64 = -2;
-    } else if #[cfg(target_os = "netbsd" )] {
-        // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
-        pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
-    }
-}
-
-cfg_if! {
-    if #[cfg(any(
-            target_os = "macos",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "dragonfly"
-    ))] {
         pub(crate) const UTIME_OMIT: i64 = -2;
     } else if #[cfg(target_os = "openbsd")] {
+        // These are swapped compared to macos, freebsd, ios, and dragonfly.
         // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
+        pub(crate) const UTIME_NOW: i64 = -2;
         pub(crate) const UTIME_OMIT: i64 = -1;
-    } else if #[cfg(target_os = "netbsd")] {
+    } else if #[cfg(target_os = "netbsd" )] {
+        // These are the same as for Linux.
         // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
+        pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
         pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
     }
 }

--- a/crates/wasi-common/src/sys/unix/bsd/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/filetime.rs
@@ -1,0 +1,104 @@
+use super::super::filetime::FileTime;
+use cfg_if::cfg_if;
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+cfg_if! {
+    if #[cfg(any(
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "dragonfly"
+    ))] {
+        pub(crate) const UTIME_NOW: i64 = -1;
+    } else if #[cfg(target_os = "openbsd")] {
+        // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
+        pub(crate) const UTIME_NOW: i64 = -2;
+    } else if #[cfg(target_os = "netbsd" )] {
+        // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
+        pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "dragonfly"
+    ))] {
+        pub(crate) const UTIME_OMIT: i64 = -2;
+    } else if #[cfg(target_os = "openbsd")] {
+        // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
+        pub(crate) const UTIME_OMIT: i64 = -1;
+    } else if #[cfg(target_os = "netbsd")] {
+        // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
+        pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
+    }
+}
+
+pub(crate) fn utimensat(
+    dirfd: &File,
+    path: &str,
+    atime: FileTime,
+    mtime: FileTime,
+    symlink: bool,
+) -> io::Result<()> {
+    use super::super::filetime::{to_timespec, utimesat};
+    use std::ffi::CString;
+    use std::os::unix::prelude::*;
+
+    // Attempt to use the `utimensat` syscall, but if it's not supported by the
+    // current kernel then fall back to an older syscall.
+    if let Some(func) = fetch_utimensat() {
+        let flags = if symlink {
+            libc::AT_SYMLINK_NOFOLLOW
+        } else {
+            0
+        };
+
+        let p = CString::new(path.as_bytes())?;
+        let times = [to_timespec(&atime), to_timespec(&mtime)];
+        let rc = unsafe { func(dirfd.as_raw_fd(), p.as_ptr(), times.as_ptr(), flags) };
+        if rc == 0 {
+            return Ok(());
+        } else {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    utimesat(dirfd, path, atime, mtime, symlink)
+}
+
+fn fetch_utimensat() -> Option<
+    unsafe extern "C" fn(
+        libc::c_int,
+        *const libc::c_char,
+        *const libc::timespec,
+        libc::c_int,
+    ) -> libc::c_int,
+> {
+    static ADDR: AtomicUsize = AtomicUsize::new(0);
+    unsafe {
+        fetch(&ADDR, CStr::from_bytes_with_nul_unchecked(b"utimensat\0"))
+            .map(|sym| std::mem::transmute(sym))
+    }
+}
+
+fn fetch(cache: &AtomicUsize, name: &CStr) -> Option<usize> {
+    match cache.load(SeqCst) {
+        0 => {}
+        1 => return None,
+        n => return Some(n),
+    }
+    let sym = unsafe { libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr() as *const _) };
+    let (val, ret) = if sym.is_null() {
+        (1, None)
+    } else {
+        (sym as usize, Some(sym as usize))
+    };
+    cache.store(val, SeqCst);
+    return ret;
+}

--- a/crates/wasi-common/src/sys/unix/bsd/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/filetime.rs
@@ -44,7 +44,7 @@ pub(crate) fn utimensat(
     path: &str,
     atime: FileTime,
     mtime: FileTime,
-    symlink: bool,
+    symlink_nofollow: bool,
 ) -> io::Result<()> {
     use super::super::filetime::{to_timespec, utimesat};
     use std::ffi::CString;
@@ -53,7 +53,7 @@ pub(crate) fn utimensat(
     // Attempt to use the `utimensat` syscall, but if it's not supported by the
     // current kernel then fall back to an older syscall.
     if let Some(func) = fetch_utimensat() {
-        let flags = if symlink {
+        let flags = if symlink_nofollow {
             libc::AT_SYMLINK_NOFOLLOW
         } else {
             0
@@ -69,7 +69,7 @@ pub(crate) fn utimensat(
         }
     }
 
-    utimesat(dirfd, path, atime, mtime, symlink)
+    utimesat(dirfd, path, atime, mtime, symlink_nofollow)
 }
 
 fn fetch_utimensat() -> Option<

--- a/crates/wasi-common/src/sys/unix/bsd/mod.rs
+++ b/crates/wasi-common/src/sys/unix/bsd/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod filetime;
 pub(crate) mod hostcalls_impl;
 pub(crate) mod osfile;
 
@@ -36,47 +37,5 @@ pub(crate) mod host_impl {
         entry.d_namlen = u32::from(host_entry.d_namlen);
         entry.d_type = d_type;
         Ok(entry)
-    }
-}
-
-pub(crate) mod fs_helpers {
-    use cfg_if::cfg_if;
-
-    pub(crate) fn utime_now() -> libc::c_long {
-        cfg_if! {
-            if #[cfg(any(
-                    target_os = "macos",
-                    target_os = "freebsd",
-                    target_os = "ios",
-                    target_os = "dragonfly"
-            ))] {
-                -1
-            } else if #[cfg(target_os = "openbsd")] {
-                // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
-                -2
-            } else if #[cfg(target_os = "netbsd" )] {
-                // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
-                1_073_741_823
-            }
-        }
-    }
-
-    pub(crate) fn utime_omit() -> libc::c_long {
-        cfg_if! {
-            if #[cfg(any(
-                    target_os = "macos",
-                    target_os = "freebsd",
-                    target_os = "ios",
-                    target_os = "dragonfly"
-            ))] {
-                -2
-            } else if #[cfg(target_os = "openbsd")] {
-                // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L187
-                -1
-            } else if #[cfg(target_os = "netbsd")] {
-                // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?rev=1.69&content-type=text/x-cvsweb-markup&only_with_tag=MAIN
-                1_073_741_822
-            }
-        }
     }
 }

--- a/crates/wasi-common/src/sys/unix/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/filetime.rs
@@ -137,6 +137,10 @@ pub(crate) fn to_timespec(ft: &FileTime) -> libc::timespec {
             tv_sec: 0,
             tv_nsec: UTIME_OMIT,
         },
+        // `filetime::FileTime`'s fields are normalised by definition. `ft.seconds()` return the number
+        // of whole seconds, while `ft.nanoseconds()` returns only fractional part expressed in
+        // nanoseconds, as underneath it uses `std::time::Duration::subsec_nanos` to populate the
+        // `filetime::FileTime::nanoseconds` field. It is, therefore, OK to do an `as` cast here.
         FileTime::FileTime(ft) => libc::timespec {
             tv_sec: ft.seconds(),
             tv_nsec: ft.nanoseconds() as _,

--- a/crates/wasi-common/src/sys/unix/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/filetime.rs
@@ -62,7 +62,7 @@ pub(crate) fn utimesat(
     path: &str,
     atime: FileTime,
     mtime: FileTime,
-    symlink: bool,
+    symlink_nofollow: bool,
 ) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::unix::prelude::*;
@@ -70,7 +70,7 @@ pub(crate) fn utimesat(
     // (fd, path)
     let p = CString::new(path.as_bytes())?;
     let mut flags = libc::O_RDWR;
-    if !symlink {
+    if symlink_nofollow {
         flags |= libc::O_NOFOLLOW;
     }
     let fd = unsafe { libc::openat(dirfd.as_raw_fd(), p.as_ptr(), flags) };

--- a/crates/wasi-common/src/sys/unix/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/filetime.rs
@@ -1,0 +1,110 @@
+use std::fs::{self, File};
+use std::io;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        pub(crate) use super::linux::filetime::*;
+    } else if #[cfg(any(
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "ios",
+            target_os = "dragonfly"
+    ))] {
+        pub(crate) use super::bsd::filetime::*;
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum FileTime {
+    Now,
+    Omit,
+    FileTime(filetime::FileTime),
+}
+
+fn get_times(
+    atime: FileTime,
+    mtime: FileTime,
+    current: impl Fn() -> io::Result<fs::Metadata>,
+) -> io::Result<(filetime::FileTime, filetime::FileTime)> {
+    use std::time::SystemTime;
+
+    let atime = match atime {
+        FileTime::Now => {
+            let time = SystemTime::now();
+            filetime::FileTime::from_system_time(time)
+        }
+        FileTime::Omit => {
+            let meta = current()?;
+            filetime::FileTime::from_last_access_time(&meta)
+        }
+        FileTime::FileTime(ft) => ft,
+    };
+
+    let mtime = match mtime {
+        FileTime::Now => {
+            let time = SystemTime::now();
+            filetime::FileTime::from_system_time(time)
+        }
+        FileTime::Omit => {
+            let meta = current()?;
+            filetime::FileTime::from_last_modification_time(&meta)
+        }
+        FileTime::FileTime(ft) => ft,
+    };
+
+    Ok((atime, mtime))
+}
+
+pub(crate) fn utimesat(
+    dirfd: &File,
+    path: &str,
+    atime: FileTime,
+    mtime: FileTime,
+    symlink: bool,
+) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::prelude::*;
+    // emulate *at syscall by reading the path from a combination of
+    // (fd, path)
+    let p = CString::new(path.as_bytes())?;
+    let mut flags = libc::O_RDWR;
+    if !symlink {
+        flags |= libc::O_NOFOLLOW;
+    }
+    let fd = unsafe { libc::openat(dirfd.as_raw_fd(), p.as_ptr(), flags) };
+    let f = unsafe { File::from_raw_fd(fd) };
+    let (atime, mtime) = get_times(atime, mtime, || f.metadata())?;
+    let times = [to_timeval(atime), to_timeval(mtime)];
+    let rc = unsafe { libc::futimes(f.as_raw_fd(), times.as_ptr()) };
+    return if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    };
+}
+
+fn to_timeval(ft: filetime::FileTime) -> libc::timeval {
+    libc::timeval {
+        tv_sec: ft.seconds(),
+        tv_usec: (ft.nanoseconds() / 1000) as libc::suseconds_t,
+    }
+}
+
+pub(crate) fn to_timespec(ft: &FileTime) -> libc::timespec {
+    match ft {
+        FileTime::Now => libc::timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_NOW,
+        },
+        FileTime::Omit => libc::timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        FileTime::FileTime(ft) => libc::timespec {
+            tv_sec: ft.seconds(),
+            tv_nsec: ft.nanoseconds() as _,
+        },
+    }
+}

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/fs.rs
@@ -292,7 +292,7 @@ pub(crate) fn path_filestat_set_times(
         return Err(Error::EINVAL);
     }
 
-    let symlink = wasi::__WASI_LOOKUP_SYMLINK_FOLLOW == dirflags;
+    let symlink_nofollow = wasi::__WASI_LOOKUP_SYMLINK_FOLLOW != dirflags;
     let atim = if set_atim {
         let time = UNIX_EPOCH + Duration::from_nanos(st_atim);
         FileTime::FileTime(filetime::FileTime::from_system_time(time))
@@ -310,7 +310,14 @@ pub(crate) fn path_filestat_set_times(
         FileTime::Omit
     };
 
-    utimensat(resolved.dirfd(), resolved.path(), atim, mtim, symlink).map_err(Into::into)
+    utimensat(
+        resolved.dirfd(),
+        resolved.path(),
+        atim,
+        mtim,
+        symlink_nofollow,
+    )
+    .map_err(Into::into)
 }
 
 pub(crate) fn path_remove_directory(resolved: PathGet) -> Result<()> {

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/fs.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/fs.rs
@@ -1,6 +1,5 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_unsafe)]
-use super::fs_helpers::*;
 use crate::helpers::systemtime_to_timestamp;
 use crate::hostcalls_impl::{FileType, PathGet};
 use crate::sys::host_impl;
@@ -281,25 +280,8 @@ pub(crate) fn path_filestat_set_times(
     st_mtim: wasi::__wasi_timestamp_t,
     fst_flags: wasi::__wasi_fstflags_t,
 ) -> Result<()> {
-    use nix::sys::stat::{utimensat, UtimensatFlags};
-    use nix::sys::time::{TimeSpec, TimeValLike};
-
-    // FIXME this should be a part of nix
-    fn timespec_omit() -> TimeSpec {
-        let raw_ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: utime_omit(),
-        };
-        unsafe { std::mem::transmute(raw_ts) }
-    };
-
-    fn timespec_now() -> TimeSpec {
-        let raw_ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: utime_now(),
-        };
-        unsafe { std::mem::transmute(raw_ts) }
-    };
+    use super::super::filetime::*;
+    use std::time::{Duration, UNIX_EPOCH};
 
     let set_atim = fst_flags & wasi::__WASI_FILESTAT_SET_ATIM != 0;
     let set_atim_now = fst_flags & wasi::__WASI_FILESTAT_SET_ATIM_NOW != 0;
@@ -310,31 +292,25 @@ pub(crate) fn path_filestat_set_times(
         return Err(Error::EINVAL);
     }
 
-    let atflags = match dirflags {
-        wasi::__WASI_LOOKUP_SYMLINK_FOLLOW => UtimensatFlags::FollowSymlink,
-        _ => UtimensatFlags::NoFollowSymlink,
-    };
-
+    let symlink = wasi::__WASI_LOOKUP_SYMLINK_FOLLOW == dirflags;
     let atim = if set_atim {
-        let st_atim = st_atim.try_into()?;
-        TimeSpec::nanoseconds(st_atim)
+        let time = UNIX_EPOCH + Duration::from_nanos(st_atim);
+        FileTime::FileTime(filetime::FileTime::from_system_time(time))
     } else if set_atim_now {
-        timespec_now()
+        FileTime::Now
     } else {
-        timespec_omit()
+        FileTime::Omit
     };
-
     let mtim = if set_mtim {
-        let st_mtim = st_mtim.try_into()?;
-        TimeSpec::nanoseconds(st_mtim)
+        let time = UNIX_EPOCH + Duration::from_nanos(st_mtim);
+        FileTime::FileTime(filetime::FileTime::from_system_time(time))
     } else if set_mtim_now {
-        timespec_now()
+        FileTime::Now
     } else {
-        timespec_omit()
+        FileTime::Omit
     };
 
-    let fd = resolved.dirfd().as_raw_fd().into();
-    utimensat(fd, resolved.path(), &atim, &mtim, atflags).map_err(Into::into)
+    utimensat(resolved.dirfd(), resolved.path(), atim, mtim, symlink).map_err(Into::into)
 }
 
 pub(crate) fn path_remove_directory(resolved: PathGet) -> Result<()> {

--- a/crates/wasi-common/src/sys/unix/hostcalls_impl/fs_helpers.rs
+++ b/crates/wasi-common/src/sys/unix/hostcalls_impl/fs_helpers.rs
@@ -4,21 +4,6 @@ use crate::sys::host_impl;
 use crate::{wasi, Result};
 use std::fs::File;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
-        pub(crate) use super::super::linux::fs_helpers::*;
-    } else if #[cfg(any(
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "freebsd",
-            target_os = "openbsd",
-            target_os = "ios",
-            target_os = "dragonfly"
-    ))] {
-        pub(crate) use super::super::bsd::fs_helpers::*;
-    }
-}
-
 pub(crate) fn path_open_rights(
     rights_base: wasi::__wasi_rights_t,
     rights_inheriting: wasi::__wasi_rights_t,

--- a/crates/wasi-common/src/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/linux/filetime.rs
@@ -1,11 +1,19 @@
+//! This internal module consists of helper types and functions for dealing
+//! with setting the file times specific to Linux.
 use super::super::filetime::FileTime;
 use std::fs::File;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 
-pub(crate) const UTIME_NOW: i64 = libc::UTIME_NOW;
-pub(crate) const UTIME_OMIT: i64 = libc::UTIME_OMIT;
+pub(crate) const UTIME_NOW: i64 = 1_073_741_823;
+pub(crate) const UTIME_OMIT: i64 = 1_073_741_822;
 
+/// Wrapper for `utimensat` syscall, however, with an added twist such that `utimensat` symbol
+/// is firstly resolved (i.e., we check whether it exists on the host), and only used if that is
+/// the case. Otherwise, the syscall resorts to a less accurate `utimesat` emulated syscall.
+/// The original implementation can be found here: [filetime::unix::linux::set_times]
+///
+/// [filetime::unix::linux::set_times]: https://github.com/alexcrichton/filetime/blob/master/src/unix/linux.rs#L64
 pub(crate) fn utimensat(
     dirfd: &File,
     path: &str,

--- a/crates/wasi-common/src/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/linux/filetime.rs
@@ -11,13 +11,13 @@ pub(crate) fn utimensat(
     path: &str,
     atime: FileTime,
     mtime: FileTime,
-    symlink: bool,
+    symlink_nofollow: bool,
 ) -> io::Result<()> {
     use super::super::filetime::{to_timespec, utimesat};
     use std::ffi::CString;
     use std::os::unix::prelude::*;
 
-    let flags = if symlink {
+    let flags = if symlink_nofollow {
         libc::AT_SYMLINK_NOFOLLOW
     } else {
         0
@@ -49,5 +49,5 @@ pub(crate) fn utimensat(
         }
     }
 
-    utimesat(dirfd, path, atime, mtime, symlink)
+    utimesat(dirfd, path, atime, mtime, symlink_nofollow)
 }

--- a/crates/wasi-common/src/sys/unix/linux/filetime.rs
+++ b/crates/wasi-common/src/sys/unix/linux/filetime.rs
@@ -1,0 +1,53 @@
+use super::super::filetime::FileTime;
+use std::fs::File;
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+
+pub(crate) const UTIME_NOW: i64 = libc::UTIME_NOW;
+pub(crate) const UTIME_OMIT: i64 = libc::UTIME_OMIT;
+
+pub(crate) fn utimensat(
+    dirfd: &File,
+    path: &str,
+    atime: FileTime,
+    mtime: FileTime,
+    symlink: bool,
+) -> io::Result<()> {
+    use super::super::filetime::{to_timespec, utimesat};
+    use std::ffi::CString;
+    use std::os::unix::prelude::*;
+
+    let flags = if symlink {
+        libc::AT_SYMLINK_NOFOLLOW
+    } else {
+        0
+    };
+
+    // Attempt to use the `utimensat` syscall, but if it's not supported by the
+    // current kernel then fall back to an older syscall.
+    static INVALID: AtomicBool = AtomicBool::new(false);
+    if !INVALID.load(SeqCst) {
+        let p = CString::new(path.as_bytes())?;
+        let times = [to_timespec(&atime), to_timespec(&mtime)];
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_utimensat,
+                dirfd.as_raw_fd(),
+                p.as_ptr(),
+                times.as_ptr(),
+                flags,
+            )
+        };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ENOSYS) {
+            INVALID.store(true, SeqCst);
+        } else {
+            return Err(err);
+        }
+    }
+
+    utimesat(dirfd, path, atime, mtime, symlink)
+}

--- a/crates/wasi-common/src/sys/unix/linux/mod.rs
+++ b/crates/wasi-common/src/sys/unix/linux/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod filetime;
 pub(crate) mod hostcalls_impl;
 pub(crate) mod osfile;
 
@@ -29,14 +30,4 @@ pub(crate) mod fdentry_impl {
 
 pub(crate) mod host_impl {
     pub(crate) const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_RSYNC;
-}
-
-pub(crate) mod fs_helpers {
-    pub(crate) fn utime_now() -> libc::c_long {
-        libc::UTIME_NOW
-    }
-
-    pub(crate) fn utime_omit() -> libc::c_long {
-        libc::UTIME_OMIT
-    }
 }

--- a/crates/wasi-common/src/sys/unix/mod.rs
+++ b/crates/wasi-common/src/sys/unix/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod host_impl;
 pub(crate) mod hostcalls_impl;
 
 mod dir;
+mod filetime;
 
 #[cfg(any(
     target_os = "macos",


### PR DESCRIPTION
This commit introduces a change to file time management for *nix based
hosts in that it firstly tries to load `utimensat` symbol, and if it
doesn't exist, then falls back to `utimes` instead. This change is
borrowing very heavily from [filetime] crate, however, it introduces a
couple of helpers and methods specific to WASI use case (or more
generally, to a use case which requires modifying times of entities
specified by a pair `(DirFD, RelativePath)` rather than the typical
file time specification based only absolute path or raw file descriptor
as is the case with [filetime] crate. The trick here is, that on kernels
which do not have `utimensat` symbol, this implementation emulates this
behaviour by a combination of `openat` and `utimes`.

This commit also is meant to address #516.

[filetime]: https://github.com/alexcrichton/filetime